### PR TITLE
Update docs to reflect new item_mip_data_processing repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "data"]
-	path = data
+	path = item/data
 	url = https://github.com/transportenergy/metadata.git

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,8 @@
 version: 2
 
+submodules:
+  include: all
+
 sphinx:
   configuration: doc/conf.py
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include data *.yaml
+recursive-include item/data *.yaml

--- a/README.md
+++ b/README.md
@@ -12,7 +12,17 @@ Tools for the iTEM databases
 2. A **historical database** to form a common, public, “best available” baseline for model calibration and projections.
    The historical database is currently *under development*.
 
-This repository contains tools for *both* databases, in *both* Python and R. The goals for these tools are that:
+This repository contains tools for:
+
+- the historical database, in Python.
+- the model database from the second iTEM model intercomparison project (MIP2), in R.
+
+Other relevant repositories:
+
+- https://github.com/transportenergy/item_mip_data_processing contains tools for iTEM MIP3.
+- https://github.com/transportenergy/metadata contains shared metadata about models and historical data sources.
+
+The goals for these tools are that:
 
 - iTEM participants use the tools to *access* either database and perform basic data manipulations such as retrieval, selection, and aggregation, in either Python, R (or possibly, in the future, other languages).
 - Members of the [iTEM organizing group](https://transportenergy.org/participants/#organizing-group) use the tools to prepare templates for data submission, and to aggregate & clean submitted data.

--- a/doc/model.rst
+++ b/doc/model.rst
@@ -1,10 +1,17 @@
 Transport energy model projections (:mod:`item.model`)
 ******************************************************
 
+- The `transportenergy/item_mip_data_processing <https://github.com/transportenergy/item_mip_data_processing>`_ repository contains R scripts for iTEM **MIP3** (2019–2020).
+- The `transportenergy/database <https://github.com/transportenergy/database>`_ repository contains:
+
+  - R scripts for the iTEM **MIP2** (2016–2017).
+  - Python tools for preparing data submission templates and plotting mode data.
+
 On separate pages:
 
 .. toctree::
 
+   model/mip2
    model/common
    model/dimensions
    model/plot

--- a/doc/model/mip2.rst
+++ b/doc/model/mip2.rst
@@ -1,0 +1,59 @@
+Using the iTEM MIP2 R scripts
+*****************************
+
+Installation
+============
+
+Use `devtools <https://cran.r-project.org/package=devtools>`_.
+From source (for instance, to develop the code locally)::
+
+    $ git clone git@github.com:transportenergy/database.git
+    $ Rscript -e "devtools::install_local('database/R/item')"
+
+Or without cloning the repository::
+
+    devtools::install_github('transportenergy/database/R/item')
+
+
+Usage
+=====
+
+From R scripts::
+
+    library(item)
+
+    # Load version 1 of the iTEM models database
+    data <- item::load_model_data(1)
+
+From the command-line: ``run`` is an executable that invokes ``item::cli()``.
+It can be used without installing the package::
+
+    $ ./run
+    Loading item
+    Usage: ./run [OPTIONS] COMMAND
+    Command-line interface for the iTEM databases.
+
+    …
+
+    Commands:
+      mkdirs
+      debug
+      load_model_data
+
+
+Development
+===========
+
+Code conventions and packaging follow the `“R packages” book <http://r-pkgs.had.co.nz/>`_.
+
+``test`` is an executable that runs the tests in ``R/item/tests/testthat``.
+The environment variable ``ITEM_TEST_DATA`` must be defined in order for these tests to work::
+
+  $ export ITEM_TEST_DATA=../../data/model/database
+  $ ./test
+  Loading item
+  Loading required package: testthat
+  Testing item
+  Model database: .
+
+  DONE =================================

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -32,16 +32,15 @@ Both the Python and R tools will operate on data stored in the following way; se
       stats     Manipulate the stats database.
       template  Generate the MIP3 submission template.
 
-Python
-======
 
 Installation
-------------
+============
 Use `pip <https://pip.pypa.io/en/stable/>`_.
 From source (for instance, to develop the code locally)::
 
-    $ git clone git@github.com:transportenergy/database.git
-    $ pip install --editable database/python
+    $ git clone --recurse-submodules git@github.com:transportenergy/database.git
+    $ cd database
+    $ pip install --editable .[doc,hist,tests]
 
 Or, without cloning the repository::
 
@@ -49,7 +48,7 @@ Or, without cloning the repository::
 
 
 Usage
------
+=====
 
 From Python scripts::
 
@@ -57,73 +56,13 @@ From Python scripts::
 
     data = item.load_model_data(1)
 
-Run tests
----------
 
-Tests in ``python/item/tests`` can be run with `py.test <https://pytest.org/>`_.
+Run tests
+=========
+
+Tests in ``item/tests`` can be run with `py.test <https://pytest.org/>`_.
 The command-line option ``--local-data`` must be defined in order for these tests to work::
 
     $ py.test --local-data=../../data/model/database item
     ================ test session starts ================
     …
-
-
-R
-===
-
-Installation
-------------
-
-Use `devtools <https://cran.r-project.org/package=devtools>`_.
-From source (for instance, to develop the code locally)::
-
-    $ git clone git@github.com:transportenergy/database.git
-    $ Rscript -e "devtools::install_local('database/R/item')"
-
-Or without cloning the repository::
-
-    devtools::install_github('transportenergy/database/R/item')
-
-
-Usage
------
-
-From R scripts::
-
-    library(item)
-
-    # Load version 1 of the iTEM models database
-    data <- item::load_model_data(1)
-
-From the command-line: ``run`` is an executable that invokes ``item::cli()``.
-It can be used without installing the package::
-
-    $ ./run
-    Loading item
-    Usage: ./run [OPTIONS] COMMAND
-    Command-line interface for the iTEM databases.
-
-    …
-
-    Commands:
-      mkdirs
-      debug
-      load_model_data
-
-
-Development
------------
-
-Code conventions and packaging follow the `“R packages” book <http://r-pkgs.had.co.nz/>`_.
-
-``test`` is an executable that runs the tests in ``R/item/tests/testthat``.
-The environment variable ``ITEM_TEST_DATA`` must be defined in order for these tests to work::
-
-  $ export ITEM_TEST_DATA=../../data/model/database
-  $ ./test
-  Loading item
-  Loading required package: testthat
-  Testing item
-  Model database: .
-
-  DONE ============================================

--- a/item/common.py
+++ b/item/common.py
@@ -20,7 +20,7 @@ paths = {
     }
 
 if not paths['data'].exists():
-    assert False, paths
+    assert False, sorted(paths['data'].rglob('*.yaml'))
     # Workaround for editable pip install
     paths['data'] = Path(__file__).parent / 'data'
 

--- a/item/common.py
+++ b/item/common.py
@@ -20,7 +20,7 @@ paths = {
     }
 
 if not paths['data'].exists():
-    assert False, sorted(paths['data'].rglob('*.yaml'))
+    assert False, sorted(paths['data'].parent.rglob('*'))
     # Workaround for editable pip install
     paths['data'] = Path(__file__).parent / 'data'
 

--- a/item/common.py
+++ b/item/common.py
@@ -20,7 +20,6 @@ paths = {
     }
 
 if not paths['data'].exists():
-    assert False, sorted(paths['data'].parent.rglob('*'))
     # Workaround for editable pip install
     paths['data'] = Path(__file__).parent / 'data'
 

--- a/item/common.py
+++ b/item/common.py
@@ -20,6 +20,7 @@ paths = {
     }
 
 if not paths['data'].exists():
+    assert False, paths
     # Workaround for editable pip install
     paths['data'] = Path(__file__).parent / 'data'
 

--- a/item/common.py
+++ b/item/common.py
@@ -21,7 +21,7 @@ paths = {
 
 if not paths['data'].exists():
     # Workaround for editable pip install
-    paths['data'] = Path(__file__).parents[1] / 'data'
+    paths['data'] = Path(__file__).parent / 'data'
 
 
 config = {}


### PR DESCRIPTION
This PR adjusts the documentation to describe the contents of the 'database' vs. 'item_mip_data_processing' vs. 'metadata' repos, per recent changes.

[Docs preview on RTD](https://transportenergy.readthedocs.io/en/update-docs/)