### PR TITLE
Download raw historical data

### DIFF
--- a/item/historical/__init__.py
+++ b/item/historical/__init__.py
@@ -1,9 +1,12 @@
+from copy import copy
+
 import pandas as pd
 import pint
 import yaml
 
-from ..common import paths
-from ..openkapsarc import OpenKAPSARC
+from item.common import paths
+from item.openkapsarc import OpenKAPSARC
+from item.remote import get_sdmx
 
 
 # List of data processing scripts/IPython notebooks
@@ -66,6 +69,34 @@ def convert_units(row, target_units=[]):
     return row
 
 
+def source_str(id):
+    """Return the canonical string name (e.g. 'T001') for a data source."""
+    return f'T{id:03}' if isinstance(id, int) else id
+
+
+def fetch_source(id):
+    """Fetch data from source *id*."""
+    # Retrieve source information from sources.yaml
+    id = source_str(id)
+    source_info = copy(SOURCES[id])
+
+    # Information for fetching the data
+    fetch_info = source_info['fetch']
+
+    remote_type = fetch_info.pop('type')
+    if remote_type == 'sdmx':
+        # Use SDMX to retrieve the data
+        result = get_sdmx(**fetch_info['args'])
+    elif remote_type == 'OpenKAPSARC':
+        pass
+    else:
+        raise ValueError(remote_type)
+
+    cache_path = paths['historical input'] / f'{id}.csv'
+    result.to_csv(cache_path)
+    return cache_path
+
+
 def input_file(id: int):
     """Return the path to a cached, raw input data file for data source *id*.
 
@@ -74,7 +105,8 @@ def input_file(id: int):
     returned.
     """
     # List of all matching files
-    all_files = sorted(paths['historical input'].glob(f'T{id:03}*.csv'))
+    all_files = sorted(paths['historical input']
+                       .glob(f'T{source_str(id)}*.csv'))
 
     # The last file has the most recent timestamp
     return all_files[-1]
@@ -162,6 +194,10 @@ def conversion_layer1(df, top_dict={}):
     df = df.apply(convert_units, axis=1, args=(preferred_units(top_dict),))
 
     return df
+
+
+with open(paths['data'] / 'historical' / 'sources.yaml') as f:
+    SOURCES = yaml.safe_load(f)
 
 
 def main(output_file, use_cache):

--- a/item/historical/cli.py
+++ b/item/historical/cli.py
@@ -4,15 +4,24 @@ from tempfile import TemporaryDirectory
 import click
 from click import Group
 
-from ..openkapsarc import OpenKAPSARC
+from item.openkapsarc import OpenKAPSARC
 from . import (
     SCRIPTS,
+    fetch_source,
     main as _phase1,
 )
 from .util import run_notebook
 
 
 historical = Group('historical', help="Manipulate the historical database.")
+
+
+@historical.command()
+@click.argument('source', type=int)
+def fetch(source):
+    """Retrieve raw data for SOURCE."""
+    path = fetch_source(source)
+    print(f'Retrieved {path}')
 
 
 @historical.command()

--- a/item/remote/__init__.py
+++ b/item/remote/__init__.py
@@ -1,0 +1,30 @@
+"""Tools to retrieve and push data."""
+import pandasdmx as sdmx
+
+
+def get_sdmx(source=None, **args):
+    """Retrieve data from *source* using pandaSDMX.
+
+    Arguments
+    ---------
+    source : str
+        Name of a data source recognized by pandaSDMX, e.g. 'OECD'.
+    args
+        Other arguments to :meth:`sdmx.Request.get`.
+
+    Returns
+    -------
+    pandas.DataFrame
+    """
+    # SDMX client for the data source
+    req = sdmx.Request(source=source)
+
+    # Retrieve the data
+    msg = req.get(resource_type='data', tofile='debug.json', **args)
+
+    # Convert to pd.DataFrame, preserving attributes
+    df = sdmx.to_pandas(msg, attributes='dgso').dropna()
+    index_cols = df.index.names
+
+    # Reset index, use categoricals
+    return df.reset_index().astype({c: 'category' for c in index_cols})

--- a/item/tests/test_historical.py
+++ b/item/tests/test_historical.py
@@ -4,8 +4,13 @@ import pytest
 
 import item
 from item.common import paths
-from item.historical import SCRIPTS, input_file
+from item.historical import SCRIPTS, fetch_source, input_file
 from item.historical.util import run_notebook
+
+
+@pytest.mark.parametrize('source_id', [1])
+def test_fetch(source_id):
+    fetch_source(source_id)
 
 
 def test_import():

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ INSTALL_REQUIRES = [
     'click',
     'openpyxl',
     'pandas',
+    'pandaSDMX >= 1.0b1',
     'pint',
     'plotnine',
     'pycountry',


### PR DESCRIPTION
This PR adds code (NB. to the `T004_script` branch of #18) to download the raw historical data which is an input to the data processing scripts.

Currently it does this (a) for OECD/T001 (b) using pandaSDMX; in time this functionality must be expanded to cover all data sets.