### PR TITLE
Automate download of input data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
 # - Rscript -e "devtools::install('R/item', dep = T)"
 
 script:
-- pytest --pyargs item --cov=item --cov-report=term-missing
+- pytest --pyargs item --cov=item --cov-report=term-missing --verbose
 
 # Disabled: MIP3 code is in a separate repository
 # - R CMD build R/item

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -4,6 +4,7 @@ jupyter
 nbformat
 openpyxl
 pandas
+git+git://github.com/dr-leo/pandaSDMX.git#egg=pandaSDMX
 pint
 plotnine
 pycountry

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    """Add command-line flags for pytest."""
+    parser.addoption('--run-slow', action='store_true', help='Run slow tests')
+
+
+def pytest_runtest_setup(item):
+    if 'slow' in item.keywords and not item.config.getoption("--run-slow"):
+        pytest.skip("Give --run-slow to run slow tests")

--- a/item/cli.py
+++ b/item/cli.py
@@ -5,6 +5,7 @@ import click
 
 from item.model.cli import model
 from item.historical.cli import historical
+from item.remote.cli import remote
 from item.utils import make_template
 
 
@@ -90,3 +91,4 @@ def template():
 
 main.add_command(model)
 main.add_command(historical)
+main.add_command(remote)

--- a/item/common.py
+++ b/item/common.py
@@ -91,7 +91,7 @@ def init_paths(**kwargs):
     init_path('models-1', paths['model database'] / '1.csv')
     init_path('models-2', paths['model database'] / '2.csv')
 
-    init_path('historical', '.')
+    init_path('historical', Path(__file__).parent / 'data' / 'historical')
     init_path('historical input', paths['historical'] / 'input')
     init_path('output', '.')
 

--- a/item/historical/__init__.py
+++ b/item/historical/__init__.py
@@ -1,4 +1,5 @@
 from copy import copy
+import os
 
 import pandas as pd
 import pint
@@ -89,14 +90,18 @@ def fetch_source(id):
     remote_type = fetch_info.pop('type')
     if remote_type == 'sdmx':
         # Use SDMX to retrieve the data
-        result = get_sdmx(**fetch_info['args'])
+        result = get_sdmx(**fetch_info)
     elif remote_type == 'OpenKAPSARC':
-        pass
+        # Retrieve data using the OpenKAPSARC API
+        ok_api = OpenKAPSARC(api_key=os.environ.get('OK_API_KEY', None))
+        result = ok_api.table(cache=False, **fetch_info)
     else:
         raise ValueError(remote_type)
 
+    # Cache the results
     cache_path = paths['historical input'] / f'{id}.csv'
     result.to_csv(cache_path, index=False)
+
     return cache_path
 
 

--- a/item/historical/__init__.py
+++ b/item/historical/__init__.py
@@ -88,10 +88,10 @@ def fetch_source(id):
     fetch_info = source_info['fetch']
 
     remote_type = fetch_info.pop('type')
-    if remote_type == 'sdmx':
+    if remote_type.lower() == 'sdmx':
         # Use SDMX to retrieve the data
         result = get_sdmx(**fetch_info)
-    elif remote_type == 'OpenKAPSARC':
+    elif remote_type.lower() == 'openkapsarc':
         # Retrieve data using the OpenKAPSARC API
         ok_api = OpenKAPSARC(api_key=os.environ.get('OK_API_KEY', None))
         result = ok_api.table(cache=False, **fetch_info)

--- a/item/historical/__init__.py
+++ b/item/historical/__init__.py
@@ -6,8 +6,7 @@ import pint
 import yaml
 
 from item.common import paths
-from item.openkapsarc import OpenKAPSARC
-from item.remote import get_sdmx
+from item.remote import OpenKAPSARC, get_sdmx
 
 
 # List of data processing scripts/IPython notebooks

--- a/item/historical/__init__.py
+++ b/item/historical/__init__.py
@@ -96,7 +96,7 @@ def fetch_source(id):
         raise ValueError(remote_type)
 
     cache_path = paths['historical input'] / f'{id}.csv'
-    result.to_csv(cache_path)
+    result.to_csv(cache_path, index=False)
     return cache_path
 
 

--- a/item/historical/__init__.py
+++ b/item/historical/__init__.py
@@ -1,9 +1,12 @@
+from copy import copy
+
 import pandas as pd
 import pint
 import yaml
 
-from ..common import paths
-from ..openkapsarc import OpenKAPSARC
+from item.common import paths
+from item.openkapsarc import OpenKAPSARC
+from item.remote import get_sdmx
 
 
 # List of data processing scripts/IPython notebooks
@@ -69,6 +72,34 @@ def convert_units(row, target_units=[]):
     return row
 
 
+def source_str(id):
+    """Return the canonical string name (e.g. 'T001') for a data source."""
+    return f'T{id:03}' if isinstance(id, int) else id
+
+
+def fetch_source(id):
+    """Fetch data from source *id*."""
+    # Retrieve source information from sources.yaml
+    id = source_str(id)
+    source_info = copy(SOURCES[id])
+
+    # Information for fetching the data
+    fetch_info = source_info['fetch']
+
+    remote_type = fetch_info.pop('type')
+    if remote_type == 'sdmx':
+        # Use SDMX to retrieve the data
+        result = get_sdmx(**fetch_info['args'])
+    elif remote_type == 'OpenKAPSARC':
+        pass
+    else:
+        raise ValueError(remote_type)
+
+    cache_path = paths['historical input'] / f'{id}.csv'
+    result.to_csv(cache_path)
+    return cache_path
+
+
 def input_file(id: int):
     """Return the path to a cached, raw input data file for data source *id*.
 
@@ -77,7 +108,8 @@ def input_file(id: int):
     returned.
     """
     # List of all matching files
-    all_files = sorted(paths['historical input'].glob(f'T{id:03}*.csv'))
+    all_files = sorted(paths['historical input']
+                       .glob(f'T{source_str(id)}*.csv'))
 
     # The last file has the most recent timestamp
     return all_files[-1]
@@ -165,6 +197,10 @@ def conversion_layer1(df, top_dict={}):
     df = df.apply(convert_units, axis=1, args=(preferred_units(top_dict),))
 
     return df
+
+
+with open(paths['data'] / 'historical' / 'sources.yaml') as f:
+    SOURCES = yaml.safe_load(f)
 
 
 def main(output_file, use_cache):

--- a/item/historical/__init__.py
+++ b/item/historical/__init__.py
@@ -93,7 +93,7 @@ def fetch_source(id):
     elif remote_type.lower() == 'openkapsarc':
         # Retrieve data using the OpenKAPSARC API
         ok_api = OpenKAPSARC(api_key=os.environ.get('OK_API_KEY', None))
-        result = ok_api.table(cache=False, **fetch_info)
+        result = ok_api.table(**fetch_info)
     else:
         raise ValueError(remote_type)
 

--- a/item/historical/__init__.py
+++ b/item/historical/__init__.py
@@ -109,7 +109,7 @@ def input_file(id: int):
     """
     # List of all matching files
     all_files = sorted(paths['historical input']
-                       .glob(f'T{source_str(id)}*.csv'))
+                       .glob(f'{source_str(id)}*.csv'))
 
     # The last file has the most recent timestamp
     return all_files[-1]

--- a/item/historical/cli.py
+++ b/item/historical/cli.py
@@ -4,15 +4,24 @@ from tempfile import TemporaryDirectory
 import click
 from click import Group
 
-from ..openkapsarc import OpenKAPSARC
+from item.openkapsarc import OpenKAPSARC
 from . import (
     SCRIPTS,
+    fetch_source,
     main as _phase1,
 )
 from .util import run_notebook
 
 
 historical = Group('historical', help="Manipulate the historical database.")
+
+
+@historical.command()
+@click.argument('source', type=int)
+def fetch(source):
+    """Retrieve raw data for SOURCE."""
+    path = fetch_source(source)
+    print(f'Retrieved {path}')
 
 
 @historical.command()

--- a/item/historical/cli.py
+++ b/item/historical/cli.py
@@ -4,7 +4,6 @@ from tempfile import TemporaryDirectory
 import click
 from click import Group
 
-from item.openkapsarc import OpenKAPSARC
 from . import (
     SCRIPTS,
     fetch_source,
@@ -22,24 +21,6 @@ def fetch(source):
     """Retrieve raw data for SOURCE."""
     path = fetch_source(source)
     print(f'Retrieved {path}')
-
-
-@historical.command()
-@click.argument('server', default=None, required=False)
-def demo(server):
-    """Access the KAPSARC APIs at the given SERVER."""
-    ok = OpenKAPSARC(server)
-
-    print('List of all datasets:')
-    for ds in ok.datasets():
-        print(ds)
-
-    print("\n\nDatasets with the 'iTEM' keyword:")
-    for ds in ok.datasets(kw='item'):
-        print(ds)
-
-    print('\n\nData from one table in a branch in a repository:')
-    print(ok.table('modal-split-of-freight-transport'))
 
 
 @historical.command()

--- a/item/openkapsarc.py
+++ b/item/openkapsarc.py
@@ -56,7 +56,7 @@ class OpenKAPSARC:
 
     """
     ALL = sys.maxsize
-    max = {'rows': 100}
+    max = {'rows': 1000}
     server = 'https://datasource.kapsarc.org/api/v2'
 
     # Alternate values include 'opendatasoft', which includes all public data
@@ -139,6 +139,10 @@ class OpenKAPSARC:
 
         cache_path = (paths['historical'] / ds.uid).with_suffix('.csv')
         log.info(f'Caching in {cache_path}')
+
+        # Set maximum rows
+        kwargs.setdefault('params', {})
+        kwargs['params'].setdefault('rows', self.max['rows'])
 
         # Stream data
         kwargs['stream'] = True

--- a/item/remote/__init__.py
+++ b/item/remote/__init__.py
@@ -1,0 +1,30 @@
+"""Tools to retrieve and push data."""
+import pandasdmx as sdmx
+
+
+def get_sdmx(source=None, **args):
+    """Retrieve data from *source* using pandaSDMX.
+
+    Arguments
+    ---------
+    source : str
+        Name of a data source recognized by pandaSDMX, e.g. 'OECD'.
+    args
+        Other arguments to :meth:`sdmx.Request.get`.
+
+    Returns
+    -------
+    pandas.DataFrame
+    """
+    # SDMX client for the data source
+    req = sdmx.Request(source=source)
+
+    # Retrieve the data
+    msg = req.get(resource_type='data', tofile='debug.json', **args)
+
+    # Convert to pd.DataFrame, preserving attributes
+    df = sdmx.to_pandas(msg, attributes='dgso').dropna()
+    index_cols = df.index.names
+
+    # Reset index, use categoricals
+    return df.reset_index().astype({c: 'category' for c in index_cols})

--- a/item/remote/__init__.py
+++ b/item/remote/__init__.py
@@ -23,7 +23,7 @@ def get_sdmx(source=None, **args):
     msg = req.get(resource_type='data', tofile='debug.json', **args)
 
     # Convert to pd.DataFrame, preserving attributes
-    df = sdmx.to_pandas(msg, attributes='dgso').dropna()
+    df = sdmx.to_pandas(msg, attributes='dgso')
     index_cols = df.index.names
 
     # Reset index, use categoricals

--- a/item/remote/__init__.py
+++ b/item/remote/__init__.py
@@ -1,30 +1,6 @@
 """Tools to retrieve and push data."""
-import pandasdmx as sdmx
+from .openkapsarc import OpenKAPSARC
+from .sdmx import get_sdmx
 
 
-def get_sdmx(source=None, **args):
-    """Retrieve data from *source* using pandaSDMX.
-
-    Arguments
-    ---------
-    source : str
-        Name of a data source recognized by pandaSDMX, e.g. 'OECD'.
-    args
-        Other arguments to :meth:`sdmx.Request.get`.
-
-    Returns
-    -------
-    pandas.DataFrame
-    """
-    # SDMX client for the data source
-    req = sdmx.Request(source=source)
-
-    # Retrieve the data
-    msg = req.get(resource_type='data', tofile='debug.json', **args)
-
-    # Convert to pd.DataFrame, preserving attributes
-    df = sdmx.to_pandas(msg, attributes='dgso')
-    index_cols = df.index.names
-
-    # Reset index, use categoricals
-    return df.reset_index().astype({c: 'category' for c in index_cols})
+__all__ = ['OpenKAPSARC', 'get_sdmx']

--- a/item/remote/cli.py
+++ b/item/remote/cli.py
@@ -1,0 +1,25 @@
+import click
+from click import Group
+
+from . import OpenKAPSARC
+
+
+remote = Group('remote', help="Access remote data sources.")
+
+
+@remote.command()
+@click.argument('server', default=None, required=False)
+def demo(server):
+    """Access the KAPSARC APIs at the given SERVER."""
+    ok = OpenKAPSARC(server)
+
+    print('List of all datasets:')
+    for ds in ok.datasets():
+        print(ds)
+
+    print("\n\nDatasets with the 'iTEM' keyword:")
+    for ds in ok.datasets(kw='item'):
+        print(ds)
+
+    print('\n\nData from one table in a branch in a repository:')
+    print(ok.table('modal-split-of-freight-transport'))

--- a/item/remote/openkapsarc.py
+++ b/item/remote/openkapsarc.py
@@ -120,8 +120,6 @@ class OpenKAPSARC:
                 raise ValueError("either give kw= or params={'where': …}")
             params['where'] = f"keyword LIKE '{kw}'"
 
-        params.setdefault('rows', self.max['rows'])
-
         result = self.endpoint('datasets', dataset_id, *args, params=params,
                                **kwargs)
 

--- a/item/remote/openkapsarc.py
+++ b/item/remote/openkapsarc.py
@@ -7,7 +7,7 @@ import requests
 import requests_cache
 
 
-from .common import config, paths
+from item.common import config, paths
 
 
 log = logging.getLogger(__name__)
@@ -39,6 +39,14 @@ class Dataset:
     @property
     def uid(self):
         return self.data['dataset']['dataset_uid']
+
+    @property
+    def record_count(self):
+        return self.data['dataset']['metas']['default']['record_count']
+
+    @property
+    def data_processed(self):
+        return self.data['dataset']['metas']['default']['data_processed']
 
     def __str__(self):
         return f"<Dataset {self.uid}: '{self.id}'>"
@@ -137,12 +145,9 @@ class OpenKAPSARC:
         # Make another request to get dataset information
         ds = self.datasets(dataset_id)
 
+        # Cache path
         cache_path = (paths['historical'] / ds.uid).with_suffix('.csv')
-        log.info(f'Caching in {cache_path}')
-
-        # Set maximum rows
-        kwargs.setdefault('params', {})
-        kwargs['params'].setdefault('rows', self.max['rows'])
+        log.info(f'Cache path {cache_path}')
 
         # Stream data
         kwargs['stream'] = True

--- a/item/remote/sdmx.py
+++ b/item/remote/sdmx.py
@@ -1,0 +1,32 @@
+import pandasdmx as sdmx
+
+
+def get_sdmx(source=None, **args):
+    """Retrieve data from *source* using pandaSDMX.
+
+    Arguments
+    ---------
+    source : str
+        Name of a data source recognized by pandaSDMX, e.g. 'OECD'.
+    args
+        Other arguments to :meth:`sdmx.Request.get`.
+
+    Returns
+    -------
+    pandas.DataFrame
+    """
+    # SDMX client for the data source
+    req = sdmx.Request(source=source)
+
+    # commented: for debugging
+    # args.setdefault('tofile', 'debug.json')
+
+    # Retrieve the data
+    msg = req.get(resource_type='data', **args)
+
+    # Convert to pd.DataFrame, preserving attributes
+    df = sdmx.to_pandas(msg, attributes='dgso')
+    index_cols = df.index.names
+
+    # Reset index, use categoricals
+    return df.reset_index().astype({c: 'category' for c in index_cols})

--- a/item/tests/test_cli.py
+++ b/item/tests/test_cli.py
@@ -7,7 +7,6 @@ import item.cli
 COMMANDS = [
     # historical
     ('historical',),
-    ('historical', 'demo'),
     ('historical', 'phase1'),
     ('historical', 'run-scripts'),
 
@@ -15,6 +14,10 @@ COMMANDS = [
     ('model',),
     ('model', 'process_raw'),
     ('model', 'list_pairs'),
+
+    # remote
+    ('remote',),
+    ('remote', 'demo'),
 
     # Top-level
     ('debug',),

--- a/item/tests/test_historical.py
+++ b/item/tests/test_historical.py
@@ -8,8 +8,9 @@ from item.historical import SCRIPTS, fetch_source, input_file
 from item.historical.util import run_notebook
 
 
-@pytest.mark.parametrize('source_id', [1])
+@pytest.mark.parametrize('source_id', [1, 2, 3])
 def test_fetch(source_id):
+    """Raw data can be fetched from individual sources."""
     fetch_source(source_id)
 
 

--- a/item/tests/test_historical.py
+++ b/item/tests/test_historical.py
@@ -12,7 +12,10 @@ from item.historical.util import run_notebook
     # OECD via SDMX
     0, 1, 2, 3,
     # OpenKAPSARC
-    5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+    5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+    pytest.param(16, marks=pytest.mark.slow),  # 1.2m records/161 MiB
+    pytest.param(17, marks=pytest.mark.slow),  # 2.5m records/317 MiB
+    18, 19, 20, 21, 22, 23, 24,
 ])
 def test_fetch(source_id):
     """Raw data can be fetched from individual sources."""

--- a/item/tests/test_historical.py
+++ b/item/tests/test_historical.py
@@ -8,7 +8,12 @@ from item.historical import SCRIPTS, fetch_source, input_file
 from item.historical.util import run_notebook
 
 
-@pytest.mark.parametrize('source_id', [1, 2, 3])
+@pytest.mark.parametrize('source_id', [
+    # OECD via SDMX
+    1, 2, 3,
+    # OpenKAPSARC
+    5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+])
 def test_fetch(source_id):
     """Raw data can be fetched from individual sources."""
     fetch_source(source_id)

--- a/item/tests/test_historical.py
+++ b/item/tests/test_historical.py
@@ -4,8 +4,13 @@ import pytest
 
 import item
 from item.common import paths
-from item.historical import SCRIPTS, input_file
+from item.historical import SCRIPTS, fetch_source, input_file
 from item.historical.util import run_notebook
+
+
+@pytest.mark.parametrize('source_id', [1])
+def test_fetch(source_id):
+    fetch_source(source_id)
 
 
 def test_import():

--- a/item/tests/test_historical.py
+++ b/item/tests/test_historical.py
@@ -10,7 +10,7 @@ from item.historical.util import run_notebook
 
 @pytest.mark.parametrize('source_id', [
     # OECD via SDMX
-    1, 2, 3,
+    0, 1, 2, 3,
     # OpenKAPSARC
     5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
 ])

--- a/item/tests/test_openkapsarc.py
+++ b/item/tests/test_openkapsarc.py
@@ -27,5 +27,5 @@ def test_dataset(ok):
 
 def test_cli(ok):
     runner = CliRunner()
-    result = runner.invoke(item.cli.main, ['historical', 'demo'])
-    assert result.exit_code == 0
+    result = runner.invoke(item.cli.main, ['remote', 'demo'])
+    assert result.exit_code == 0, result.output

--- a/item/tests/test_openkapsarc.py
+++ b/item/tests/test_openkapsarc.py
@@ -21,7 +21,8 @@ def test_dataset(ok):
     # Retrieve single dataset
     result = ok.table('modal-split-of-freight-transport')
     assert isinstance(result, pd.DataFrame)
-    assert len(result) == 1458
+    # NB sometimes 1406, sometimes 1458
+    assert len(result) > 1400
 
 
 def test_cli(ok):

--- a/item/tests/test_openkapsarc.py
+++ b/item/tests/test_openkapsarc.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 
 import item.cli
-from item.openkapsarc import OpenKAPSARC
+from item.remote import OpenKAPSARC
 
 
 @pytest.fixture(scope='module')

--- a/item/tests/test_openkapsarc.py
+++ b/item/tests/test_openkapsarc.py
@@ -21,7 +21,7 @@ def test_dataset(ok):
     # Retrieve single dataset
     result = ok.table('modal-split-of-freight-transport')
     assert isinstance(result, pd.DataFrame)
-    assert len(result) == 1406
+    assert len(result) == 1458
 
 
 def test_cli(ok):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
 [tool:pytest]
 markers =
-  slow: Mark a test as slow.
+  slow: mark a test as slow.
+  network: mark a test that requires a network connection.
 addopts = --cov=item --cov-report=term-missing --cov-config=ci/coveragerc

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ INSTALL_REQUIRES = [
     'click',
     'openpyxl',
     'pandas',
+    'pandaSDMX >= 1.0b1',
     'pint',
     'plotnine',
     'pycountry',

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ INSTALL_REQUIRES = [
     'click',
     'openpyxl',
     'pandas',
-    'pandaSDMX >= 1.0b1',
+    'pandaSDMX >= 1.0.0b2',
     'pint',
     'plotnine',
     'pycountry',


### PR DESCRIPTION
As of #18, the input data for the historical database are stored in the transportenergy/metadata repostory. For the historical database to actually be reproducible, these files must be retrieved automatically, from original, public sources.

This PR adds code to download the data which is an input for the processing scripts. It does this for sources that can be read using either SDMX or the OpenKAPSARC API, i.e. datasets T001–T024, excluding T004. The number of lines (= observations, since these files are all in long format):
```
$ wc -l historical/input/*
      289 historical/input/S012_input.csv
     9240 historical/input/T000.csv
     9227 historical/input/T000_input.csv
     1581 historical/input/T001.csv
     1580 historical/input/T001_input.csv
     6541 historical/input/T002.csv
     6482 historical/input/T002_input.csv
    13225 historical/input/T003.csv
    13213 historical/input/T003_input.csv
    16151 historical/input/T004_input.csv
     9317 historical/input/T005.csv
     3363 historical/input/T005_input.csv
     9190 historical/input/T006.csv
     1407 historical/input/T006_input.csv
     6597 historical/input/T007.csv
     2555 historical/input/T007_input.csv
    17118 historical/input/T008.csv
     9034 historical/input/T008_input.csv
    20801 historical/input/T009.csv
      141 historical/input/T009_input.csv
     1016 historical/input/T010.csv
      141 historical/input/T010_input.csv
     1407 historical/input/T011.csv
     1407 historical/input/T012.csv
      415 historical/input/T013.csv
    38361 historical/input/T014.csv
    81696 historical/input/T015.csv
  1154989 historical/input/T016.csv
  2473186 historical/input/T017.csv
    32356 historical/input/T018.csv
     1834 historical/input/T019.csv
     5908 historical/input/T020.csv
      867 historical/input/T021.csv
     3428 historical/input/T022.csv
     4081 historical/input/T023.csv
    87766 historical/input/T024.csv
```


This functionality must eventually be expanded to cover all data sources.

Supersedes #19.