### PR TITLE
Use sdmx1 to generate data template

### DIFF
--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -1,22 +1,5 @@
-Common code
-***********
-
-Utilities (:mod:`item.utils`)
-=============================
-
-.. automodule:: item.utils
-   :members:
-
-
-Tools for fetching remote data (:mod:`item.remote`)
-===================================================
-
-.. automodule:: item.remote
-   :members:
-
-
 Command-line interface (:mod:`item.cli`)
-========================================
+****************************************
 
 The command ``item`` is installed with the package.
 The CLI provides help with the ``--help`` option::
@@ -37,7 +20,4 @@ The CLI provides help with the ``--help`` option::
       mkdirs      Create a directory tree for the database.
       model       Manipulate the model database.
       remote      Access remote data sources.
-      template    Generate the MIP3 submission template.
-
-.. automodule:: item.cli
-   :members:
+      template    Generate the MIP submission template.

--- a/doc/developing.rst
+++ b/doc/developing.rst
@@ -1,8 +1,8 @@
-Reference
-*********
+Development notes
+*****************
 
 Repository organization
------------------------
+=======================
 
 - ``item/`` — Python code for accessing & maintaining the database.
 
@@ -24,7 +24,7 @@ Repository organization
 
 
 Style guide
------------
+===========
 
 - Follow `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_; use a linter to ensure compliance.
 - Document all public classes and functions following the `NumPy docstring

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -24,8 +24,11 @@ This documentation, built automatically from the `transportenergy/database GitHu
    usage
    model
    historical
-   common
-   reference
+   structure
+   remote
+   cli
+   metadata
+   developing
 
 
 * :ref:`genindex`

--- a/doc/metadata.rst
+++ b/doc/metadata.rst
@@ -1,0 +1,50 @@
+Metadata
+********
+
+Metadata (i.e. data that describe iTEM data) are stored in the public `transportenergy/metadata <https://github.com/transportenergy/metadata>`_ repository.
+This page displays some of these metadata files.
+
+To make use of these files:
+
+- Install :mod:`item` and use its methods to retrieve the files in useful Python data formats.
+- Include this repository as a `git submodule <https://git-scm.com/book/en/v2/Git-Tools-Submodules>`_—as is done in the transportenergy/database repo used to build the :mod:`item` package and this documentation.
+
+.. contents::
+   :local:
+
+
+.. _concepts-yaml:
+
+Concept schemes (:file:`concepts.yaml`)
+=======================================
+
+iTEM uses the :mod:`sdmx` notion of a "concept scheme": a (possibly) hierarchical list of distinct concepts.
+Per the :ref:`SDMX 'information model' <sdmx:im-base-classes>`, each of these :class:`.Concepts` has an `id` and optionally a `name`, a `description`, and one or more annotations.
+
+The concepts in :file:`concepts.yaml` are all measured using *discrete, unordered codes*: for instance, the 'lca_scope' of a particular data observation might be 'ttw', 'wtt', or one of the other values.
+
+In contrast, the :ref:`measures <measures-yaml>` below are measured in *continuous, quantiative* values.
+
+.. literalinclude:: ../item/data/concepts.yaml
+   :language: yaml
+
+
+.. _measures-yaml:
+
+Measures (:file:`measures.yaml`)
+================================
+
+'measure' is another :ref:`Concept Scheme <concepts-yaml>`.
+Each measure also has an annotation specifying `units`; see :func:`add_unit`.
+
+.. literalinclude:: ../item/data/measures.yaml
+   :language: yaml
+
+
+.. _spec-yaml:
+
+iTEM template specification (:file:`spec.yaml`)
+===============================================
+
+.. literalinclude:: ../item/data/spec.yaml
+   :language: yaml

--- a/doc/remote.rst
+++ b/doc/remote.rst
@@ -1,0 +1,5 @@
+Fetching remote data (:mod:`item.remote`)
+*****************************************
+
+.. automodule:: item.remote
+   :members:

--- a/doc/structure.rst
+++ b/doc/structure.rst
@@ -1,0 +1,24 @@
+Data structures
+***************
+
+.. currentmodule:: item.structure
+
+.. autofunction:: make_template
+
+
+Code reference
+==============
+
+.. automodule:: item.structure
+   :members:
+   :exclude-members: make_template
+
+   The following utility functions are used by :func:`make_template`:
+
+   .. autosummary::
+
+      add_unit
+      collapse
+      common_dim_dummies
+      read_concepts_yaml
+      read_measures_yaml

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -13,24 +13,7 @@ Both the Python and R tools will operate on data stored in the following way; se
 3. Copy the file ``item_config_example.yaml`` to ``item_config.yaml`` in any working directory where you intend to use this code.
    Edit the file (see the inline comments) to point to the directories created in #2 above.
 
-4. Use the tools through the command-line interface::
-
-    $ item
-    Usage: item [OPTIONS] COMMAND [ARGS]...
-
-      Command-line interface for the iTEM databases.
-
-    Options:
-      --path <KEY> <PATH>  Override data paths (multiple allowed).
-      --help               Show this message and exit.
-
-    Commands:
-      debug     Show debugging information, including paths.
-      help      Show extended help for the command-line tool.
-      mkdirs    Create a directory tree for the database.
-      model     Manipulate the model database.
-      stats     Manipulate the stats database.
-      template  Generate the MIP3 submission template.
+4. Use the tools through the :doc:`cli`.
 
 
 Installation

--- a/item/cli.py
+++ b/item/cli.py
@@ -6,7 +6,7 @@ import click
 from item.model.cli import model
 from item.historical.cli import historical
 from item.remote.cli import remote
-from item.utils import make_template
+from item.structure import make_template
 
 
 @click.group(help=__doc__)

--- a/item/cli.py
+++ b/item/cli.py
@@ -85,7 +85,7 @@ def mkdirs(path, dry_run):
 
 @main.command()
 def template():
-    """Generate the MIP3 submission template."""
+    """Generate the MIP submission template."""
     make_template()
 
 

--- a/item/structure.py
+++ b/item/structure.py
@@ -158,7 +158,7 @@ def read_measures(path):
     return measures
 
 
-def make_template(verbose=True):
+def make_template(output_path=None, verbose=True):
     """Generate a data template.
 
     Outputs files containing all keys specified in 'spec.yaml'. The file is
@@ -283,11 +283,11 @@ def make_template(verbose=True):
         # Combine 3 concepts with 'measure' ("Variable")
         lca_scope = row.pop('lca_scope')
         if len(lca_scope):
-           row['measure'] += ' (' + lca_scope + ')'
+            row['measure'] += ' (' + lca_scope + ')'
 
         pollutant = row.pop('pollutant')
         if len(pollutant):
-           row['measure'] = pollutant + ' ' + row['measure']
+            row['measure'] = pollutant + ' ' + row['measure']
 
         fleet = row.pop('fleet')
         if len(fleet):
@@ -338,8 +338,10 @@ def make_template(verbose=True):
               sep='\n\n')
 
     # Save in multiple formats
-    specs.to_csv(paths['output'] / 'template.csv', index=False)
-    specs.to_excel(paths['output'] / 'template.xlsx', index=False)
+    output_path = output_path or paths['output']
+
+    specs.to_csv(output_path / 'template.csv', index=False)
+    specs.to_excel(output_path / 'template.xlsx', index=False)
 
     # Save the index
     index = {'Full dimensionality': specs_full, 'Template (reduced)': specs}
@@ -347,5 +349,5 @@ def make_template(verbose=True):
               .drop(columns=common_dims + list(map(str.title, common_dims)),
                     axis=1, level=1) \
               .replace('', '---')
-    index.to_csv(paths['output'] / 'index.csv')
-    index.to_excel(paths['output'] / 'index.xlsx')
+    index.to_csv(output_path / 'index.csv')
+    index.to_excel(output_path / 'index.xlsx')

--- a/item/tests/test_dimensions.py
+++ b/item/tests/test_dimensions.py
@@ -2,7 +2,7 @@ import pytest
 
 from item.common import paths
 from item.model.dimensions import check, generate, list_pairs
-from item.utils import make_template
+from item.structure import make_template
 
 
 @pytest.mark.skip('Requires synthetic model data.')
@@ -22,6 +22,6 @@ def test_check(item_tmp_dir):
     check(dims, item_tmp_dir / 'check.tsv')
 
 
-def test_make_template():
-    make_template()
-    assert (paths['output'] / 'template.csv').exists()
+def test_make_template(tmp_path):
+    make_template(output_path=tmp_path)
+    assert (tmp_path / 'template.csv').exists()

--- a/item/tests/test_dimensions.py
+++ b/item/tests/test_dimensions.py
@@ -2,7 +2,6 @@ import pytest
 
 from item.common import paths
 from item.model.dimensions import check, generate, list_pairs
-from item.structure import make_template
 
 
 @pytest.mark.skip('Requires synthetic model data.')
@@ -20,8 +19,3 @@ def test_generate():
 def test_check(item_tmp_dir):
     dims = generate()
     check(dims, item_tmp_dir / 'check.tsv')
-
-
-def test_make_template(tmp_path):
-    make_template(output_path=tmp_path)
-    assert (tmp_path / 'template.csv').exists()

--- a/item/tests/test_structure.py
+++ b/item/tests/test_structure.py
@@ -1,0 +1,12 @@
+from item.structure import make_template
+
+
+def test_make_template(tmp_path):
+    make_template(output_path=tmp_path)
+
+    # Produces 4 files
+    for name in ['index.csv', 'index.xlsx', 'template.csv', 'template.xlsx']:
+        assert (tmp_path / name).exists()
+
+    assert 2493 + 1 == sum(1 for _ in open(tmp_path / 'template.csv'))
+    assert 2493 + 2 == sum(1 for _ in open(tmp_path / 'index.csv'))

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     pprint
     pycountry
     pyyaml
-    sdmx1
+    sdmx1 >= 1.0.2
     setuptools >= 41
     xarray
 setup_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ console_scripts =
     item = item.cli:main
 
 [tool:pytest]
+addopts = --cov=item --cov-config=ci/coveragerc --cov-report=
 markers =
     slow: mark a test as slow.
     network: mark a test that requires a network connection.
-addopts = --cov=item --cov-report=term-missing --cov-config=ci/coveragerc


### PR DESCRIPTION
This PR adjusts the module `item.structure`, that generates the data template based on some specifications, to use [SDMX](https://sdmx1.rtfd.io) objects for simplicity.

It also expands the documentation of this code, and includes the metadata files in the built documentation.