### PR TITLE
Generate data structures in SDMX

### DIFF
--- a/.github/workflows/0-pytest.yaml
+++ b/.github/workflows/0-pytest.yaml
@@ -7,9 +7,15 @@ on:
     branches: [ master ]
 
 env:
+  # Location of RCLONE configuration file
+  RCLONE_CONFIG: ci/rclone.conf
+  # Path & URL fragments for uploaded historical data & diagnostics
   gcs_bucket: gcs:data.transportenergy.org/historical/ci/
   gcs_url: https://storage.googleapis.com/data.transportenergy.org/historical/ci/
-  RCLONE_CONFIG: ci/rclone.conf
+  # True if the event is a pull request and the incoming branch is within the
+  # transportenergy/database repo (as opposed to a fork). Only under this
+  # condition is the GCS_SERVICE_ACCOUNT_* secret available.
+  pr_from_main_repo: github.event_name == 'pull_request' && startsWith(github.event.pull_request.head.label, 'transportenergy:')
 
 jobs:
   pytest:
@@ -59,7 +65,7 @@ jobs:
       uses: codecov/codecov-action@v1
 
     - name: Install rclone
-      if: ${{ startsWith(github.event.head.label, 'transportenergy:') && matrix.run-diagnostics }}
+      if: env.pr_from_main_repo && matrix.run-diagnostics
       env:
         service_account_json: ${{ secrets.GCS_SERVICE_ACCOUNT_1 }}
       run: |
@@ -72,15 +78,13 @@ jobs:
         echo "$service_account_json" >ci/service-account-key.json
 
     - name: Create diagnostics and upload to Google Cloud Storage
-      # Only on PRs from the main repo
-      if: ${{ startsWith(github.event.head.label, 'transportenergy:') && matrix.run-diagnostics }}
+      if: env.pr_from_main_repo && matrix.run-diagnostics
       run: |
         item historical diagnostics output/
         rclone --progress copy output ${{ env.gcs_bucket }}${{ github.run_number }}/
 
     - uses: LouisBrunner/checks-action@v1.1.1
-      # Only on PRs from the main repo
-      if: ${{ startsWith(github.event.head.label, 'transportenergy:') && matrix.run-diagnostics }}
+      if: env.pr_from_main_repo && matrix.run-diagnostics
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         name: Upload historical database & diagnostics

--- a/doc/metadata.rst
+++ b/doc/metadata.rst
@@ -12,34 +12,13 @@ To make use of these files:
 .. contents::
    :local:
 
+.. _structure-xml:
 
-.. _concepts-yaml:
+SDMX metadata (:file:`structure.xml`)
+=====================================
 
-Concept schemes (:file:`concepts.yaml`)
-=======================================
-
-iTEM uses the :mod:`sdmx` notion of a "concept scheme": a (possibly) hierarchical list of distinct concepts.
-Per the :ref:`SDMX 'information model' <sdmx:im-base-classes>`, each of these :class:`.Concepts` has an `id` and optionally a `name`, a `description`, and one or more annotations.
-
-The concepts in :file:`concepts.yaml` are all measured using *discrete, unordered codes*: for instance, the 'lca_scope' of a particular data observation might be 'ttw', 'wtt', or one of the other values.
-
-In contrast, the :ref:`measures <measures-yaml>` below are measured in *continuous, quantiative* values.
-
-.. literalinclude:: ../item/data/concepts.yaml
-   :language: yaml
-
-
-.. _measures-yaml:
-
-Measures (:file:`measures.yaml`)
-================================
-
-'measure' is another :ref:`Concept Scheme <concepts-yaml>`.
-Each measure also has an annotation specifying `units`; see :func:`add_unit`.
-
-.. literalinclude:: ../item/data/measures.yaml
-   :language: yaml
-
+.. literalinclude:: ../item/data/structure.xml
+   :language: xml
 
 .. _spec-yaml:
 

--- a/doc/structure.rst
+++ b/doc/structure.rst
@@ -1,17 +1,62 @@
 Data structures
 ***************
 
-.. currentmodule:: item.structure
+iTEM defines :doc:`metadata <metadata>` using the SDMX information model, in order to specify the contents and various formats/representations of both the :doc:`historical <historical>` and :doc:`model projection <model>` data flows and data sets.
 
-.. autofunction:: make_template
+Overview
+========
+
+This section briefly summarizes the contents of the iTEM :ref:`structure-xml`.
+It does not give a complete or exhaustive terminology for SDMX; see the :doc:`sdmx:resources` page in the :mod:`sdmx` documentation for further reading.
+
+It is common to call certain things “columns”; this creates problems because it conflates the *logical structure* of data with a *particular representation*, e.g. in a table.
+By describing the structure itself, we allow for multiple representations that are suitable for different purposes, yet easily interoperable.
+
+General
+   All the data structures have a uniform resource name (URN) like: ``urn:sdmx:org.sdmx.infomodel.datastructure.DataStructureDefinition=iTEM:HISTORICAL(0.1)``.
+   This identifies:
+
+   - what kind of object it is (here, a data structure definition, or DSD).
+   - who the reponsible Organization or Agency is (iTEM).
+   - the ID of the thing (``HISTORICAL`` DSD), and
+   - a version number (0.1).
+
+   Specific data need not copy the entire DSD, merely refer to it using the URN.
+   The DSD can be updated over time, incrementing the version, while references to older versions remain valid.
+
+Concept scheme ``TRANSPORT``
+   This scheme includes concepts that are commonly used as dimensions or attributes for transport data.
+   These are typically represented by a set of discrete codes.
+
+   Each Concept is an SDMX ‘Item’ and so it has an *id* (usually in upper case), and optionally a *name* and *description* (both can be multi-lingual), and zero or more annotations.
+
+Concept scheme ``TRANSPORT_MEASURES``
+   This scheme includes concepts that are *measures*, i.e. the thing that is measured by the quantity (magnitude and unit) of a particular observation.
+
+Code lists
+   :file:`structure.xml` includes lists of codes used to represent particular concepts.
+   For instance, ``CL_LCA_SCOPE`` gives three Codes with the ids “TTW”, “WTT”, and “WTW”.
+   (As Items, Codes can also have plain-language names and longer descriptions. The ID is used for a short, machine readable representation.)
+
+   A statement like “this data set has a dimension ``LCA_SCOPE`` that represents the concept ``LCA_SCOPE`` using the code list ``CL_LCA_SCOPE``” is clear and unambiguous about the structure of that particular data set.
+   A econd data set can be described as having “an *attribute* ``LCA_SCOPE`` that represents the concept ``LCA_SCOPE`` using the code list ``CL_LCA_SCOPE``”; this is a distinct structure and representation, but completely interoperable with the first.
 
 
 Code reference
 ==============
 
+.. currentmodule:: item.sdmx
+
+.. automodule:: item.sdmx
+   :members:
+
+.. currentmodule:: item.structure
+
+.. autofunction:: make_template
+
 .. automodule:: item.structure
    :members:
-   :exclude-members: make_template
+   :exclude-members: make_template, read_items, read_concepts_yaml, read_measures_yaml
 
    The following utility functions are used by :func:`make_template`:
 
@@ -20,5 +65,3 @@ Code reference
       add_unit
       collapse
       common_dim_dummies
-      read_concepts_yaml
-      read_measures_yaml

--- a/doc/structure.rst
+++ b/doc/structure.rst
@@ -33,13 +33,65 @@ Concept scheme ``TRANSPORT``
 Concept scheme ``TRANSPORT_MEASURES``
    This scheme includes concepts that are *measures*, i.e. the thing that is measured by the quantity (magnitude and unit) of a particular observation.
 
+Concept scheme ``MODELING``
+   This scheme includes concepts related to model-based research, including ``MODEL``, ``SCENARIO`` ,etc.
+
 Code lists
    :file:`structure.xml` includes lists of codes used to represent particular concepts.
    For instance, ``CL_LCA_SCOPE`` gives three Codes with the ids “TTW”, “WTT”, and “WTW”.
    (As Items, Codes can also have plain-language names and longer descriptions. The ID is used for a short, machine readable representation.)
 
    A statement like “this data set has a dimension ``LCA_SCOPE`` that represents the concept ``LCA_SCOPE`` using the code list ``CL_LCA_SCOPE``” is clear and unambiguous about the structure of that particular data set.
-   A econd data set can be described as having “an *attribute* ``LCA_SCOPE`` that represents the concept ``LCA_SCOPE`` using the code list ``CL_LCA_SCOPE``”; this is a distinct structure and representation, but completely interoperable with the first.
+   A second data set can be described as having “an *attribute* ``LCA_SCOPE`` that represents the concept ``LCA_SCOPE`` using the code list ``CL_LCA_SCOPE``”; this is a distinct structure and representation, but completely interoperable with the first.
+
+The structure can also be retrieved using :func:`generate` and manipulated programmatically; this is the preferred way to obtain and use data structure information in code that works with iTEM data.
+For example:
+
+.. code-block:: python
+
+    >>> from item.structure import generate
+
+    # Generate an SDMX "structure message" containing all the data structures
+    >>> sm = generate()
+
+    # Select the historical data structure definition
+    >>> sm.structure["HISTORICAL"]
+    <DataStructureDefinition iTEM:HISTORICAL(0.1)>
+
+    # Show the dimensions of the data structure
+    >>> dsd = sm.structure["HISTORICAL"]
+    >>> dsd.dimensions
+    <DimensionDescriptor: <Dimension SERVICE>; <Dimension MODE>; <Dimension VEHICLE>; <Dimension FUEL>; <Dimension TECHNOLOGY>; <Dimension AUTOMATION>; <Dimension OPERATOR>; <Dimension POLLUTANT>; <Dimension LCA_SCOPE>; <Dimension FLEET>; <MeasureDimension VARIABLE>>
+
+    # Get one dimension
+    >>> dim = dsd.dimensions.get("LCA_SCOPE")
+    >>> dim
+    <Dimension LCA_SCOPE>
+
+    # Navigate from the dimension to the list of codes used to represent it
+    >>> dim.local_representation.enumerated
+    <Codelist iTEM:CL_LCA_SCOPE(0.1) (4 items)>
+
+    # Show the codes in this code list
+    >>> codelist = dim.local_representation.enumerated
+    >>> codelist.items
+    {'_Z': <Code _Z: Not applicable>,
+     'TTW': <Code TTW: Tank-to-wheels>,
+     'WTT': <Code WTT: Well-to-tank>,
+     'WTW': <Code WTW: Well-to-wheels>}
+
+    # Show the valid concepts to appear in the VARIABLE dimension
+    >>> dsd.dimensions.get("VARIABLE").local_representation.enumerated.items
+    {'ACTIVITY': <Concept ACTIVITY: Transport activity>,
+     'ENERGY': <Concept ENERGY: Energy>,
+     'ENERGY_INTENSITY': <Concept ENERGY_INTENSITY: Energy intensity of activity>,
+     'EMISSION': <Concept EMISSION: Emission>,
+     'GDP': <Concept GDP: Gross Domestic Product>,
+     'LOAD_FACTOR': <Concept LOAD_FACTOR: Load factor>,
+     'POPULATION': <Concept POPULATION: Population>,
+     'PRICE': <Concept PRICE: Price>,
+     'SALES': <Concept SALES: Sales>,
+     'STOCK': <Concept STOCK: Stock>}
 
 
 Code reference

--- a/item/cli.py
+++ b/item/cli.py
@@ -1,4 +1,5 @@
 """Command-line interface for the iTEM databases."""
+from pathlib import Path
 from textwrap import indent
 
 import click
@@ -6,7 +7,6 @@ import click
 from item.historical.cli import historical
 from item.model.cli import model
 from item.remote.cli import remote
-from item.structure import make_template
 
 
 @click.group(help=__doc__)
@@ -90,7 +90,22 @@ def mkdirs(path, dry_run):
 @main.command()
 def template():
     """Generate the MIP submission template."""
+    from item.structure import make_template
+
     make_template()
+
+
+@main.command("update-dsd")
+def update_dsd():
+    """Generate the iTEM SDMX data structures.
+
+    The file item/data/structure.xml is updated.
+    """
+    import sdmx
+    from item.sdmx import generate
+
+    with open(Path(__file__).parent / "data" / "structure.xml", "wb") as f:
+        f.write(sdmx.to_xml(generate(), pretty_print=True))
 
 
 main.add_command(model)

--- a/item/cli.py
+++ b/item/cli.py
@@ -103,7 +103,7 @@ def update_dsd():
     """
     import sdmx
 
-    from item.sdmx import generate
+    from item.structure import generate
 
     with open(Path(__file__).parent / "data" / "structure.xml", "wb") as f:
         f.write(sdmx.to_xml(generate(), pretty_print=True))

--- a/item/cli.py
+++ b/item/cli.py
@@ -102,6 +102,7 @@ def update_dsd():
     The file item/data/structure.xml is updated.
     """
     import sdmx
+
     from item.sdmx import generate
 
     with open(Path(__file__).parent / "data" / "structure.xml", "wb") as f:

--- a/item/common.py
+++ b/item/common.py
@@ -3,17 +3,9 @@ import logging.config
 import os
 from os.path import abspath, join
 from pathlib import Path
-from warnings import filterwarnings
 
 import yaml
 from pkg_resources import resource_filename  # noqa: F401
-
-# Occurs with pandas 0.20 and xarray 0.9.1
-filterwarnings(
-    "ignore",
-    message=".*pandas.tslib module is deprecated.*",
-    module="xarray.core.formatting",
-)
 
 # Various paths to data
 paths = {

--- a/item/common.py
+++ b/item/common.py
@@ -48,14 +48,21 @@ def load_config(path=None):
 def init(path=None):
     load_config(path)
     init_paths()
+    init_log()
 
 
-def init_log(verbose=True):
+def init_log(verbose=True, file=False):
     with open(Path(__file__).with_name("logging.yaml")) as f:
         log_config = yaml.safe_load(f)
 
     # Set up the log file
-    log_config["handlers"]["file_handler"]["filename"] = paths["log"] / "item.log"
+    if file:
+        log_config["handlers"]["file_handler"]["filename"] = paths["log"] / "item.log"
+    else:
+        del log_config["handlers"]["file_handler"]
+        log_config["root"]["handlers"].pop(
+            log_config["root"]["handlers"].index("file_handler")
+        )
 
     # Activate verbose output
     if verbose:
@@ -100,12 +107,7 @@ def init_paths(**kwargs):
 
 def log(*items, level=logging.INFO):
     """Write a collection of *items* to the log."""
-    if _logger is None:
-        init_log()
-    if level == logging.INFO:
-        _logger.info(*items)
-    elif level == logging.DEBUG:
-        _logger.debug(*items)
+    logging.getLogger("item").log(level, *items)
 
 
 def make_database_dirs(path, dry_run):

--- a/item/historical/__init__.py
+++ b/item/historical/__init__.py
@@ -128,6 +128,7 @@ def fetch_source(id, use_cache=True):
     cache_path = paths["historical input"] / f"{id}.csv"
 
     if use_cache and cache_path.exists():
+        log.info(f"From cache at {cache_path}")
         return cache_path
 
     # Information for fetching the data

--- a/item/historical/scripts/T000.py
+++ b/item/historical/scripts/T000.py
@@ -4,9 +4,8 @@ from functools import lru_cache
 import pandas as pd
 
 from item.historical.util import dropna_logged
+from item.structure import column_name
 from item.utils import convert_units
-
-from .util.managers.dataframe import ColumnName
 
 #: Dimensions and attributes which do not vary across this data set.
 COMMON_DIMS = dict(
@@ -97,5 +96,5 @@ def mode_and_vehicle_type(variable_name):
 
     return pd.Series(
         [vehicle_type, mode],
-        index=[ColumnName.VEHICLE_TYPE.value, ColumnName.MODE.value],
+        index=[column_name("VEHICLE"), column_name("MODE")],
     )

--- a/item/historical/scripts/T004.py
+++ b/item/historical/scripts/T004.py
@@ -46,7 +46,7 @@ COLUMNS = dict(
 MAP = {
     "Type of vehicle": {
         # Columns to which the values should be assigned
-        "_columns": (column_name("TYPE"), column_name("VEHICLE")),
+        "_columns": (column_name("SERVICE"), column_name("VEHICLE")),
         # Key is the value appearing in the variable column; values are a tuple for the
         # two columns
         "New lorries (vehicle wt over 3500 kg)": ("Freight", "Heavy Truck"),

--- a/item/historical/scripts/T004.py
+++ b/item/historical/scripts/T004.py
@@ -22,7 +22,7 @@ from functools import lru_cache
 
 import pandas as pd
 
-from .util.managers.dataframe import ColumnName
+from item.structure import column_name
 
 #: Separator character for :func:`pandas.read_csv`.
 CSV_SEP = ";"
@@ -46,7 +46,7 @@ COLUMNS = dict(
 MAP = {
     "Type of vehicle": {
         # Columns to which the values should be assigned
-        "_columns": (ColumnName.SERVICE.value, ColumnName.VEHICLE_TYPE.value),
+        "_columns": (column_name("TYPE"), column_name("VEHICLE")),
         # Key is the value appearing in the variable column; values are a tuple for the
         # two columns
         "New lorries (vehicle wt over 3500 kg)": ("Freight", "Heavy Truck"),
@@ -56,7 +56,7 @@ MAP = {
         "New light goods vehicles": ("Freight", "Light Truck"),
     },
     "Fuel type": {
-        "_columns": (ColumnName.TECHNOLOGY.value, ColumnName.FUEL.value),
+        "_columns": (column_name("TECHNOLOGY"), column_name("FUEL")),
         "- LPG": ("Natural Gas Vehicle", "Natural Gas"),
         "- Compressed natural gas (CNG)": ("Natural Gas Vehicle", "Natural Gas"),
         "- Liquefied natural gas (LNG)": ("Natural Gas Vehicle", "Natural Gas"),
@@ -80,7 +80,7 @@ MAP = {
 
 
 def process(df):
-    df = df.rename(columns={"Date": ColumnName.YEAR.value})
+    df = df.rename(columns={"Date": column_name("YEAR")})
 
     # U
     return pd.concat(

--- a/item/historical/scripts/T004.py
+++ b/item/historical/scripts/T004.py
@@ -45,8 +45,8 @@ COLUMNS = dict(
 #: Mapping between existing values and values to be assigned.
 MAP = {
     "Type of vehicle": {
-        # Columns to which the values should be assigned
-        "_columns": (column_name("SERVICE"), column_name("VEHICLE")),
+        # Dimensions to which the values should be assigned
+        "_dims": ("SERVICE", "VEHICLE"),
         # Key is the value appearing in the variable column; values are a tuple for the
         # two columns
         "New lorries (vehicle wt over 3500 kg)": ("Freight", "Heavy Truck"),
@@ -56,7 +56,7 @@ MAP = {
         "New light goods vehicles": ("Freight", "Light Truck"),
     },
     "Fuel type": {
-        "_columns": (column_name("TECHNOLOGY"), column_name("FUEL")),
+        "_dims": ("TECHNOLOGY", "FUEL"),
         "- LPG": ("Natural Gas Vehicle", "Natural Gas"),
         "- Compressed natural gas (CNG)": ("Natural Gas Vehicle", "Natural Gas"),
         "- Liquefied natural gas (LNG)": ("Natural Gas Vehicle", "Natural Gas"),
@@ -96,4 +96,6 @@ def process(df):
 @lru_cache()
 def map_column(value, column):
     """Apply mapping to `value` in `column`."""
-    return pd.Series(MAP[column][value], index=MAP[column]["_columns"])
+    return pd.Series(
+        MAP[column][value], index=list(map(column_name, MAP[column]["_dims"]))
+    )

--- a/item/historical/scripts/T009.py
+++ b/item/historical/scripts/T009.py
@@ -14,7 +14,6 @@ COMMON_DIMS = dict(
 
 
 COLUMNS = dict(
-    drop=["frequency"],
     rename=dict(
         country_name="Country",
         date="Year",

--- a/item/sdmx.py
+++ b/item/sdmx.py
@@ -1,0 +1,173 @@
+from datetime import datetime
+from pathlib import Path
+
+import sdmx
+import sdmx.model as m
+import sdmx.message as msg
+from sdmx.model import Code, Concept
+
+
+VERSION = "0.1"
+
+
+def generate():
+    sm = msg.StructureMessage(prepared=datetime.now())
+
+    item = m.Agency(
+        id="iTEM",
+        name="International Transport Energy Modeling",
+        contact=[
+            m.Contact(
+                name="iTEM organizing group",
+                email=["mail@transportenergy.org"],
+                uri=["https://transportenergy.org"],
+            )
+        ],
+    )
+
+    ma_args = dict(
+        maintainer=item,
+        version=VERSION,
+        is_external_reference=False,
+    )
+
+    as_ = m.AgencyScheme(id="iTEM", **ma_args)
+    as_.append(item)
+    sm.organisation_scheme[as_.id] = as_
+    sm.header = msg.Header(sender=item)
+
+    cs = m.ConceptScheme(id="TRANSPORT", **ma_args)
+    cs.extend(CONCEPTS)
+    sm.concept_scheme[cs.id] = cs
+
+    for id, codes in CODELISTS.items():
+        cl = m.Codelist(id=f"CL_{id}", **ma_args)
+        cl.extend(codes)
+        sm.codelist[cl.id] = cl
+
+    dsd0 = m.DataStructureDefinition(
+        id="HISTORICAL",
+        **ma_args,
+        description=(
+            "Structure of the 'unified' iTEM historical transport data. This DSD has "
+            "all possible dimensions, regardless of whether a particular measure "
+            "(represented in the 'VARIABLE' dimension) is relevant for that measure. "
+            "In the future, the historical data will be provided via multiple data "
+            "flows, each with a distinct structure that reflects the dimensions that "
+            "are valid for the relevant measure(s)."
+        ),
+    )
+    for order, dim in enumerate(
+        (
+            "TYPE MODE VEHICLE FUEL TECHNOLOGY AUTOMATION OPERATOR POLLUTANT LCA_SCOPE "
+            "FLEET"
+        ).split()
+    ):
+        d = m.Dimension(
+            id=dim, name=cs[dim].name, concept_identity=cs[dim], order=order
+        )
+        dsd0.dimensions.append(d)
+    dsd0.dimensions.append(m.MeasureDimension(id="VARIABLE", name="Measure"))
+
+    sm.structure[dsd0.id] = dsd0
+
+    with open(Path(__file__).parent / "data" / "structure.xml", "wb") as f:
+        f.write(sdmx.to_xml(sm, pretty_print=True))
+
+
+CONCEPTS = (
+    # Used as dimensions
+    Concept(id="TYPE", name="Objects being transported, e.g. passengers or freight"),
+    Concept(id="MODE", name="Mode or medium of transport"),
+    Concept(id="VEHICLE", name="Type of transport vehicle"),
+    Concept(id="FUEL", name="Fuel or energy carrier for transport"),
+    Concept(
+        id="TECHNOLOGY",
+        name="Powertrain technology",
+        description="Energy conversion technology used to power a motorized vehicle",
+    ),
+    Concept(
+        id="AUTOMATION", name="Degree of automation in operation of transport vehicles"
+    ),
+    Concept(id="OPERATOR", name="Entity operating a transport vehicle"),
+    Concept(id="POLLUTANT", name="Species of environmental pollutant"),
+    Concept(
+        id="LCA_SCOPE",
+        name="LCA scope",
+        description="Scope of analysis covered by a transport life-cycle measure",
+    ),
+    Concept(
+        id="FLEET",
+        description="Part of a fleet of transport vehicles, e.g. new versus used.",
+    ),
+    # Used as measures
+    Concept(
+        id="ACTIVITY",
+        name="Transport activity",
+        description=(
+            "Amount of travel or transport by a person, vehicle, or collection of "
+            "these."
+        ),
+    ),
+    Concept(id="ENERGY", name="Energy"),
+    Concept(id="ENERGY_INTENSITY", name="Energy intensity of activity"),
+    Concept(id="EMISSION", name="Emission", description="Mass of a pollutant emitted."),
+    Concept(id="GDP", name="Gross Domestic Product"),
+    Concept(
+        id="LOAD_FACTOR",
+        name="Load factor",
+        description="Amount of activity provided per vehicle",
+    ),
+    Concept(id="POPULATION", name="Population", description="i.e. of people."),
+    Concept(
+        id="PRICE", name="Price", description="Market or fixed price for commodity."
+    ),
+    Concept(id="SALES", name="Sales", description="New sales of vehicles in a period."),
+    Concept(id="STOCK", name="Stock", description="Quantity of transport vehicles."),
+)
+
+CL_LCA_SCOPE = (
+    Code(id="TTW", name="Tank-to-wheels"),
+    Code(id="WTT", name="Well-to-tank"),
+    Code(id="WTW", name="Well-to-wheels"),
+)
+
+CL_MODE = (
+    Code(id="ALL", name="All", description="All transport modes."),
+    Code(id="AIR", name="Aviation"),
+    Code(id="LAND", name="Land transport"),
+    Code(id="ROAD", name="Road"),
+    Code(id="RAIL", name="Rail"),
+    Code(id="WATER", name="Water"),
+)
+
+CL_OPERATOR = (
+    Code(
+        id="OWN",
+        name="Own-supplied",
+        description=(
+            "Transport by a vehicle owned and operated for private use by a household "
+            "or individual."
+        ),
+    ),
+    Code(
+        id="HIRE",
+        name="Hired",
+        description=(
+            "Transport by a vehicle (and driver) hired through a firm or commercial "
+            "service."
+        ),
+    ),
+)
+
+CL_TYPE = (
+    Code(id="P", name="Passenger"),
+    Code(id="F", name="Freight"),
+)
+
+CODELISTS = {
+    "LCA_SCOPE": CL_LCA_SCOPE,
+    "MODE": CL_MODE,
+    "OPERATOR": CL_OPERATOR,
+    "TYPE": CL_TYPE,
+}

--- a/item/sdmx.py
+++ b/item/sdmx.py
@@ -1,7 +1,5 @@
 from datetime import datetime
-from pathlib import Path
 
-import sdmx
 import sdmx.model as m
 import sdmx.message as msg
 from sdmx.model import Code, Concept
@@ -10,7 +8,8 @@ from sdmx.model import Code, Concept
 VERSION = "0.1"
 
 
-def generate():
+def generate() -> msg.StructureMessage:
+    """Return the SDMX data structures for iTEM data."""
     sm = msg.StructureMessage(prepared=datetime.now())
 
     item = m.Agency(
@@ -71,8 +70,7 @@ def generate():
 
     sm.structure[dsd0.id] = dsd0
 
-    with open(Path(__file__).parent / "data" / "structure.xml", "wb") as f:
-        f.write(sdmx.to_xml(sm, pretty_print=True))
+    return sm
 
 
 CONCEPTS = (

--- a/item/sdmx.py
+++ b/item/sdmx.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from functools import lru_cache
 
 import sdmx.message as msg
 import sdmx.model as m

--- a/item/sdmx.py
+++ b/item/sdmx.py
@@ -489,7 +489,22 @@ DATA_STRUCTURES = (
     DataStructureDefinition(id="PRICE_FUEL", **_annotate(_dimensions="FUEL")),
     DataStructureDefinition(id="PRICE_POLLUTANT", **_annotate(_dimensions="POLLUTANT")),
     DataStructureDefinition(
-        id="LOAD_FACTOR", **_annotate(_dimensions="SERVICE MODE VEHICLE")
+        id="LOAD_FACTOR",
+        description=(
+            "The current version of this structure does not distinguish by powertrain "
+            "technology. Implicitly TECHNOLOGY is 'ALL', so the observations measure "
+            "the average load factor across all powertrain technologies."
+        ),
+        **_annotate(_dimensions="SERVICE MODE VEHICLE"),
+    ),
+    DataStructureDefinition(
+        id="STOCK",
+        description=(
+            "The current version of this structure does not distinguish by FLEET. "
+            "Implicitly FLEET is 'ALL', so the observations measure the total of new "
+            "and used vehicles."
+        ),
+        **_annotate(_dimensions="SERVICE MODE VEHICLE TECHNOLOGY"),
     ),
     DataStructureDefinition(
         id="HISTORICAL",
@@ -541,5 +556,14 @@ CONSTRAINTS = (
         id="PRICE_POLLUTANT",
         role=_allowable,
         **_annotate(_data_content_keys={"POLLUTANT": ["GHG"]}),
+    ),
+    ContentConstraint(
+        id="STOCK",
+        description=(
+            "The current iTEM:STOCK data structure is only specified for road transport"
+            " vehicles. It excludes e.g. stock of aircraft or ships."
+        ),
+        role=_allowable,
+        **_annotate(_data_content_keys={"MODE": ["ROAD"]}),
     ),
 )

--- a/item/sdmx.py
+++ b/item/sdmx.py
@@ -20,8 +20,15 @@ def update_object(obj, properties):
         setattr(obj, name, value)
 
 
+@lru_cache()
 def generate() -> msg.StructureMessage:
-    """Return the SDMX data structures for iTEM data."""
+    """Return the SDMX data structures for iTEM data.
+
+    .. todo::
+       - Add ``REF_AREA`` and ``TIME_PERIOD`` dimensions with reference to
+         ``SDMX/CROSS_DOMAIN_CONCEPTS``.
+       - Add ``MODEL`` and ``SCENARIO`` dimensions to the DSD.
+    """
     sm = msg.StructureMessage(prepared=datetime.now())
 
     item = m.Agency(

--- a/item/sdmx.py
+++ b/item/sdmx.py
@@ -94,9 +94,15 @@ def generate() -> msg.StructureMessage:
         update_object(dsd, ma_args)
 
         # Pop an annotation and use it to produce a list of dimension IDs (see below)
-        dims_annotation = dsd.annotations.pop(-1)
-        assert "_dimensions" == dims_annotation.id
-        dims = dims_annotation.text.localized_default().split()
+        try:
+            dims_annotation = dsd.annotations.pop(-1)
+            assert "_dimensions" == dims_annotation.id
+            dims = dims_annotation.text.localized_default().split()
+        except IndexError:
+            dims = []
+
+        # Add common dimensions
+        dims = dims + ["REF_AREA", "TIME_PERIOD"]
 
         # Add dimensions to the data structure
         for order, concept_id in enumerate(dims):
@@ -439,6 +445,8 @@ CODELISTS = {
 
 #: Main iTEM data structures.
 DATA_STRUCTURES = (
+    DataStructureDefinition(id="GDP"),
+    DataStructureDefinition(id="POPULATION"),
     DataStructureDefinition(
         id="HISTORICAL",
         description=(
@@ -451,7 +459,7 @@ DATA_STRUCTURES = (
         ),
         **_dims(
             "VARIABLE SERVICE MODE VEHICLE FUEL TECHNOLOGY AUTOMATION OPERATOR "
-            "POLLUTANT LCA_SCOPE FLEET REF_AREA TIME_PERIOD"
+            "POLLUTANT LCA_SCOPE FLEET"
         ),
     ),
     DataStructureDefinition(
@@ -466,7 +474,7 @@ DATA_STRUCTURES = (
         ),
         **_dims(
             "MODEL SCENARIO VARIABLE SERVICE MODE VEHICLE FUEL TECHNOLOGY AUTOMATION "
-            "OPERATOR POLLUTANT LCA_SCOPE FLEET REF_AREA TIME_PERIOD"
+            "OPERATOR POLLUTANT LCA_SCOPE FLEET"
         ),
     ),
 )

--- a/item/sdmx.py
+++ b/item/sdmx.py
@@ -84,8 +84,8 @@ def generate() -> msg.StructureMessage:
     )
     for order, concept_id in enumerate(
         (
-            "TYPE MODE VEHICLE FUEL TECHNOLOGY AUTOMATION OPERATOR POLLUTANT LCA_SCOPE "
-            "FLEET"
+            "SERVICE MODE VEHICLE FUEL TECHNOLOGY AUTOMATION OPERATOR POLLUTANT "
+            "LCA_SCOPE FLEET"
         ).split()
     ):
         concept = sm.concept_scheme["TRANSPORT"][concept_id]
@@ -123,7 +123,11 @@ CONCEPTS = {
     "TRANSPORT": (
         # Used as dimensions
         Concept(
-            id="TYPE", name="Objects being transported, e.g. passengers or freight"
+            id="SERVICE",
+            name="Service",
+            description=(
+                "Type of transport service e.g. transport of passengers or of freight."
+            ),
         ),
         Concept(id="MODE", name="Mode or medium of transport"),
         Concept(
@@ -177,8 +181,8 @@ CONCEPTS = {
             ),
             **_units(
                 {
-                    "TYPE == passenger": "10⁹ passenger-km / yr",
-                    "TYPE == freight": "10⁹ tonne-km / yr",
+                    "SERVICE == passenger": "10⁹ passenger-km / yr",
+                    "SERVICE == freight": "10⁹ tonne-km / yr",
                     # TODO distinguish "10⁹ vehicle-km / yr"
                 }
             ),
@@ -211,8 +215,8 @@ CONCEPTS = {
             description="Amount of activity provided per vehicle",
             **_units(
                 {
-                    "TYPE == PASSENGER": "passenger / vehicle",
-                    "TYPE == FREIGHT": "tonne / vehicle",
+                    "SERVICE == PASSENGER": "passenger / vehicle",
+                    "SERVICE == FREIGHT": "tonne / vehicle",
                 }
             ),
         ),
@@ -371,7 +375,7 @@ CL_POLLUTANT = (
     ),
 )
 
-CL_TYPE = (
+CL_SERVICE = (
     Code(id="P", name="Passenger"),
     Code(id="F", name="Freight"),
 )
@@ -397,6 +401,6 @@ CODELISTS = {
     "MODE": CL_MODE,
     "OPERATOR": CL_OPERATOR,
     "POLLUTANT": CL_POLLUTANT,
-    "TYPE": CL_TYPE,
+    "SERVICE": CL_SERVICE,
     "VEHICLE": CL_VEHICLE,
 }

--- a/item/sdmx.py
+++ b/item/sdmx.py
@@ -352,6 +352,7 @@ CONCEPT_SCHEMES = [
 ]
 
 CL_AUTOMATION = (
+    Code(id="_T", name="Total"),
     Code(id="_Z", name="Not applicable"),
     Code(id="HUMAN", name="Human", description="Vehicle operated by a human driver."),
     Code(
@@ -360,8 +361,12 @@ CL_AUTOMATION = (
 )
 
 CL_FLEET = (
+    Code(
+        id="_T",
+        name="Total",
+        description="All vehicles in use in the reporting period.",
+    ),
     Code(id="_Z", name="Not applicable"),
-    Code(id="ALL", description="All vehicles in use in the reporting period."),
     Code(id="NEW", description="Only newly-sold vehicles in the reporting period."),
     Code(
         id="USED",
@@ -372,8 +377,8 @@ CL_FLEET = (
 )
 
 CL_FUEL = (
+    Code(id="_T", name="Total", description="All fuels."),
     Code(id="_Z", name="Not applicable"),
-    Code(id="ALL", description="All fuels."),
     Code(
         id="LIQUID",
         name="All liquid",
@@ -385,8 +390,8 @@ CL_FUEL = (
         ],
     ),
     Code(id="NG", name="Natural gas"),
-    Code(id="HYDROGEN"),
-    Code(id="ELECTRICITY"),
+    Code(id="H2", name="Hydrogen"),
+    Code(id="ELEC", name="Electricity"),
 )
 
 CL_LCA_SCOPE = (
@@ -397,16 +402,28 @@ CL_LCA_SCOPE = (
 )
 
 CL_MODE = (
+    Code(id="_T", name="Total", description="All transport modes."),
     Code(id="_Z", name="Not applicable"),
-    Code(id="ALL", name="All", description="All transport modes."),
     Code(id="AIR", name="Aviation"),
-    Code(id="LAND", name="Land transport"),
-    Code(id="ROAD", name="Road"),
-    Code(id="RAIL", name="Rail"),
+    Code(
+        id="LAND",
+        name="All land transport modes.",
+        child=[
+            Code(id="RAIL", name="Rail"),
+            Code(id="ROAD", name="Road", description="Motorized road transport."),
+            Code(
+                id="OFFROAD",
+                name="Off-road",
+                description="Motorized off-road transport.",
+            ),
+            Code(id="ACTIVE", name="Non-motorized"),
+        ],
+    ),
     Code(id="WATER", name="Water"),
 )
 
 CL_OPERATOR = (
+    Code(id="_T", name="Total"),
     Code(id="_Z", name="Not applicable"),
     Code(
         id="OWN",
@@ -435,9 +452,7 @@ CL_POLLUTANT = (
             "Greenhouse gases. Where used for totals, all GHGs are conveted to an "
             "equivalence basis."
         ),
-        child=[
-            Code(id="CO2", name="CO₂", description="Carbon dioxide."),
-        ],
+        child=[Code(id="CO2", name="CO₂", description="Carbon dioxide.")],
     ),
     Code(
         id="AQ",
@@ -462,20 +477,42 @@ CL_POLLUTANT = (
 )
 
 CL_SERVICE = (
+    Code(id="_T", name="Total"),
     Code(id="_Z", name="Not applicable"),
     Code(id="P", name="Passenger"),
     Code(id="F", name="Freight"),
 )
 
-CL_VEHICLE = (
+CL_TECHNOLOGY = (
+    Code(id="_T", name="Total", description="All technologies."),
     Code(id="_Z", name="Not applicable"),
-    Code(id="ALL", description="All vehicle types."),
+    Code(
+        id="IC",
+        name="Combustion",
+        description=(
+            "Using only chemical fuels. Inclusive of powertrains that store energy as"
+            "electricity, i.e. hybrids."
+        ),
+    ),
+    Code(id="ELECTRIC"),
+    Code(id="HYBRID", description="Using both electricity and chemical fuels."),
+    Code(
+        id="FC",
+        name="Fuel cell",
+        description="Using electrochemical conversion of fuel to electricity.",
+    ),
+)
+
+CL_VEHICLE = (
+    Code(id="_T", name="Total", description="All vehicle types."),
+    Code(id="_Z", name="Not applicable"),
     Code(
         id="LDV",
+        name="Light-duty vehicle",
         description="Light-duty road vehicle, including cars, SUVs, and light trucks.",
     ),
-    Code(id="BUS"),
-    Code(id="TRUCK"),
+    Code(id="BUS", name="Bus"),
+    Code(id="TRUCK", name="Truck"),
     Code(id="2W+3W", description="Two- and three-wheeled road vehicles."),
 )
 
@@ -490,6 +527,7 @@ CODELISTS = {
     "OPERATOR": CL_OPERATOR,
     "POLLUTANT": CL_POLLUTANT,
     "SERVICE": CL_SERVICE,
+    "TECHNOLOGY": CL_TECHNOLOGY,
     "VEHICLE": CL_VEHICLE,
 }
 

--- a/item/sdmx.py
+++ b/item/sdmx.py
@@ -25,6 +25,17 @@ def _annotate(**kwargs):
     return dict(annotations=[Annotation(id=k, text=repr(v)) for k, v in kwargs.items()])
 
 
+def _get_anno(obj, id):
+    """Wrapper around :meth:`AnnotableArtefact.get_annotation`.
+
+    Like :func:`_pop_anno`, but doesn't remove the annotation.
+    """
+    try:
+        return eval(obj.get_annotation(id=id).text.localized_default())
+    except KeyError:
+        return None
+
+
 def _pop_anno(obj, id):
     """Wrapper around :meth:`AnnotableArtefact.pop_annotation`.
 

--- a/item/sdmx.py
+++ b/item/sdmx.py
@@ -7,7 +7,7 @@ from sdmx.model import Annotation, Code, Concept, ConceptScheme
 
 #: Current version of all data structures.
 #:
-#: .. todo: Allow a different version for each particular structure, e.g. code list.
+#: .. todo:: Allow a different version for each particular structure, e.g. code list.
 VERSION = "0.1"
 
 

--- a/item/sdmx.py
+++ b/item/sdmx.py
@@ -195,9 +195,10 @@ def generate() -> msg.StructureMessage:
     return sm
 
 
-CONCEPTS = {
-    #: Concepts for the ``iTEM:TRANSPORT`` concept scheme.
-    "TRANSPORT": (
+CS_TRANSPORT = m.ConceptScheme(
+    id="TRANSPORT",
+    description="Concepts used as dimensions or attributes for transport data.",
+    items=[
         # Used as dimensions
         Concept(
             id="SERVICE",
@@ -226,15 +227,23 @@ CONCEPTS = {
         Concept(id="POLLUTANT", name="Species of environmental pollutant"),
         Concept(
             id="LCA_SCOPE",
-            name="LCA scope",
+            name="Life-cycle analysis scope",
             description="Scope of analysis covered by a transport life-cycle measure",
         ),
         Concept(
             id="FLEET",
-            description="Part of a fleet of transport vehicles, e.g. new versus used.",
+            name="Fleet",
+            description=(
+                "Portion of a fleet of transport vehicles, e.g. new versus used."
+            ),
         ),
-    ),
-    "MODELING": (
+    ],
+)
+
+CS_MODELING = m.ConceptScheme(
+    id="MODELING",
+    description="Concepts related to model-based research & assessment.",
+    items=[
         Concept(
             id="MODEL",
             name="Model",
@@ -247,8 +256,13 @@ CONCEPTS = {
                 "Name or other identifier of a specific configuration of a model."
             ),
         ),
-    ),
-    "TRANSPORT_MEASURE": (
+    ],
+)
+
+CS_TRANSPORT_MEASURE = m.ConceptScheme(
+    id="TRANSPORT_MEASURE",
+    description="Concepts used as measures in transport data.",
+    items=[
         Concept(
             id="ACTIVITY",
             name="Transport activity",
@@ -271,8 +285,8 @@ CONCEPTS = {
             **_annotate(preferred_units="MJ / vehicle-km"),
         ),
         Concept(
-            id="EMISSION",
-            name="Emission",
+            id="EMISSIONS",
+            name="Emissions",
             description="Mass of a pollutant emitted.",
             **_annotate(
                 preferred_units={
@@ -332,24 +346,11 @@ CONCEPTS = {
             description="Quantity of transport vehicles.",
             **_annotate(preferred_units="10⁶ vehicle"),
         ),
-    ),
-}
+    ],
+)
 
 #: Concept schemes.
-CONCEPT_SCHEMES = [
-    ConceptScheme(
-        id="TRANSPORT",
-        description="Concepts used as dimensions or attributes for transport data.",
-    ),
-    ConceptScheme(
-        id="MODELING",
-        description="Concepts related to model-based research & assessment.",
-    ),
-    ConceptScheme(
-        id="TRANSPORT_MEASURE",
-        description="Concepts used as measures in transport data.",
-    ),
-]
+CONCEPT_SCHEMES = [CS_TRANSPORT, CS_MODELING, CS_TRANSPORT_MEASURE]
 
 CL_AUTOMATION = (
     Code(id="_T", name="Total"),

--- a/item/sdmx.py
+++ b/item/sdmx.py
@@ -2,12 +2,17 @@ from datetime import datetime
 
 import sdmx.message as msg
 import sdmx.model as m
-from sdmx.model import Code, Concept, ConceptScheme
+from sdmx.model import Annotation, Code, Concept, ConceptScheme
 
 #: Current version of all data structures.
 #:
 #: .. todo: Allow a different version for each particular structure, e.g. code list.
 VERSION = "0.1"
+
+
+def _units(mapping):
+    """Generate an annotation with preferred units."""
+    return dict(annotations=[Annotation(id="preferred_unit", text=repr(mapping))])
 
 
 def update_object(obj, properties):
@@ -157,27 +162,79 @@ CONCEPTS = {
                 "Amount of travel or transport by a person, vehicle, or collection of "
                 "these."
             ),
+            **_units(
+                {
+                    "TYPE == passenger": "10⁹ passenger-km / yr",
+                    "TYPE == freight": "10⁹ tonne-km / yr",
+                    # TODO distinguish "10⁹ vehicle-km / yr"
+                }
+            ),
         ),
-        Concept(id="ENERGY", name="Energy"),
-        Concept(id="ENERGY_INTENSITY", name="Energy intensity of activity"),
+        Concept(id="ENERGY", name="Energy", **_units("PJ / yr")),
         Concept(
-            id="EMISSION", name="Emission", description="Mass of a pollutant emitted."
+            id="ENERGY_INTENSITY",
+            name="Energy intensity of activity",
+            **_units("MJ / vehicle-km"),
         ),
-        Concept(id="GDP", name="Gross Domestic Product"),
+        Concept(
+            id="EMISSION",
+            name="Emission",
+            description="Mass of a pollutant emitted.",
+            **_units(
+                {
+                    "POLLUTANT == CO2": "10⁶ t CO₂ / yr",
+                    "POLLUTANT == GHG": "10⁶ t CO₂e / yr",
+                    "POLLUTANT == BC": "1O³ t BC / yr",
+                    "POLLUTANT == PM25": "1O³ t PM2.5 / yr",
+                }
+            ),
+        ),
+        Concept(
+            id="GDP", name="Gross Domestic Product", **_units("10⁹ USD(2005) / year")
+        ),
         Concept(
             id="LOAD_FACTOR",
             name="Load factor",
             description="Amount of activity provided per vehicle",
+            **_units(
+                {
+                    "TYPE == PASSENGER": "passenger / vehicle",
+                    "TYPE == FREIGHT": "tonne / vehicle",
+                }
+            ),
         ),
-        Concept(id="POPULATION", name="Population", description="i.e. of people."),
         Concept(
-            id="PRICE", name="Price", description="Market or fixed price for commodity."
+            id="POPULATION",
+            name="Population",
+            description="i.e. of people.",
+            **_units("10⁶ persons"),
         ),
         Concept(
-            id="SALES", name="Sales", description="New sales of vehicles in a period."
+            id="PRICE",
+            name="Price",
+            description="Market or fixed price for commodity.",
+            **_units(
+                {
+                    "POLLUTANT == CO2": "USD(2005) / t CO₂",
+                    "POLLUTANT == GHG": "USD(2005) / t CO₂e",
+                    "FUEL == GASOLINE": "USD(2005) / litre",
+                    "FUEL == DIESEL": "USD(2005) / litre",
+                    "FUEL == NG": "USD(2005) / litre",
+                    "FUEL == ELECTRICITY": "USD(2005) / kW-h",
+                }
+            ),
         ),
         Concept(
-            id="STOCK", name="Stock", description="Quantity of transport vehicles."
+            id="SALES",
+            name="Sales",
+            description="New sales of vehicles in a period.",
+            **_units("10⁶ vehicle / yr"),
+        ),
+        Concept(
+            id="STOCK",
+            name="Stock",
+            description="Quantity of transport vehicles.",
+            **_units("10⁶ vehicle"),
         ),
     ),
 }

--- a/item/sdmx.py
+++ b/item/sdmx.py
@@ -126,7 +126,9 @@ CONCEPTS = {
             id="TYPE", name="Objects being transported, e.g. passengers or freight"
         ),
         Concept(id="MODE", name="Mode or medium of transport"),
-        Concept(id="VEHICLE", name="Type of transport vehicle"),
+        Concept(
+            id="VEHICLE", name="Vehicle type", description="Type of transport vehicle"
+        ),
         Concept(id="FUEL", name="Fuel or energy carrier for transport"),
         Concept(
             id="TECHNOLOGY",

--- a/item/sdmx.py
+++ b/item/sdmx.py
@@ -498,6 +498,10 @@ DATA_STRUCTURES = (
         **_annotate(_dimensions="SERVICE MODE VEHICLE"),
     ),
     DataStructureDefinition(
+        id="SALES",
+        **_annotate(_dimensions="SERVICE MODE VEHICLE TECHNOLOGY FLEET"),
+    ),
+    DataStructureDefinition(
         id="STOCK",
         description=(
             "The current version of this structure does not distinguish by FLEET. "
@@ -556,6 +560,16 @@ CONSTRAINTS = (
         id="PRICE_POLLUTANT",
         role=_allowable,
         **_annotate(_data_content_keys={"POLLUTANT": ["GHG"]}),
+    ),
+    ContentConstraint(
+        id="SALES",
+        description=(
+            "The current iTEM:SALES data structure is only specified for new road "
+            " transport vehicles. It excludes e.g. sales of aircraft or ships; and "
+            "(re)sale of used road vehicles."
+        ),
+        role=_allowable,
+        **_annotate(_data_content_keys={"FLEET": ["NEW"], "MODE": ["ROAD"]}),
     ),
     ContentConstraint(
         id="STOCK",

--- a/item/sdmx.py
+++ b/item/sdmx.py
@@ -99,6 +99,9 @@ def generate() -> msg.StructureMessage:
             id="VARIABLE",
             name="Measure",
             description="Reference to a concept from CL_TRANSPORT_MEASURES.",
+            local_representation=m.Representation(
+                enumerated=sm.concept_scheme["TRANSPORT_MEASURE"]
+            ),
         )
     )
 

--- a/item/sdmx.py
+++ b/item/sdmx.py
@@ -49,7 +49,12 @@ def generate() -> msg.StructureMessage:
 
     for id, codes in CODELISTS.items():
         cl = m.Codelist(id=f"CL_{id}", **ma_args)
-        cl.extend(codes)
+        # Add each code and any children
+        # TODO Move this upstream
+        for c in codes:
+            cl.append(c)
+            cl.extend(c.child)
+
         sm.codelist[cl.id] = cl
 
     dsd0 = m.DataStructureDefinition(
@@ -193,6 +198,41 @@ CONCEPT_SCHEMES = [
     ),
 ]
 
+CL_AUTOMATION = (
+    Code(id="HUMAN", name="Human", description="Vehicle operated by a human driver."),
+    Code(
+        id="AV", name="Automated", description="Fully-automated (self-driving) vehicle."
+    ),
+)
+
+CL_FLEET = (
+    Code(id="ALL", description="All vehicles in use in the reporting period."),
+    Code(id="NEW", description="Only newly-sold vehicles in the reporting period."),
+    Code(
+        id="USED",
+        description=(
+            "Only used vehicles that were not manufactured in the reporting period."
+        ),
+    ),
+)
+
+CL_FUEL = (
+    Code(id="ALL", description="All fuels."),
+    Code(
+        id="LIQUID",
+        name="All liquid",
+        child=[
+            Code(id="DIESEL"),
+            Code(id="GASOLINE"),
+            Code(id="BIOFUEL", name="Liquid biofuel"),
+            Code(id="SYNTHETIC", description="a.k.a. synfuels, electrofuels."),
+        ],
+    ),
+    Code(id="NG", name="Natural gas"),
+    Code(id="HYDROGEN"),
+    Code(id="ELECTRICITY"),
+)
+
 CL_LCA_SCOPE = (
     Code(id="TTW", name="Tank-to-wheels"),
     Code(id="WTT", name="Well-to-tank"),
@@ -227,15 +267,66 @@ CL_OPERATOR = (
     ),
 )
 
+CL_POLLUTANT = (
+    Code(
+        id="GHG",
+        name="GHG",
+        description=(
+            "Greenhouse gases. Where used for totals, all GHGs are conveted to an "
+            "equivalence basis."
+        ),
+        child=[
+            Code(id="CO2", name="CO₂", description="Carbon dioxide."),
+        ],
+    ),
+    Code(
+        id="AQ",
+        description="Air quality-related pollutant species.",
+        child=[
+            Code(id="BC", name="BC", description="Black carbon."),
+            Code(
+                id="NOX",
+                name="NOx",
+                description=(
+                    "Air quality-related nitrogen oxides, i.e. NO, NO₂, and N₂O."
+                ),
+            ),
+            Code(
+                id="PM25",
+                name="PM2.5",
+                description="Particulate matter smaller than 2.5 μm.",
+            ),
+            Code(id="SO2", name="SO₂", description="Sulfur dioxide."),
+        ],
+    ),
+)
+
 CL_TYPE = (
     Code(id="P", name="Passenger"),
     Code(id="F", name="Freight"),
 )
 
+CL_VEHICLE = (
+    Code(id="ALL", description="All vehicle types."),
+    Code(
+        id="LDV",
+        description="Light-duty road vehicle, including cars, SUVs, and light trucks.",
+    ),
+    Code(id="BUS"),
+    Code(id="TRUCK"),
+    Code(id="2W+3W", description="Two- and three-wheeled road vehicles."),
+)
+
+
 #: Codes for various code lists.
 CODELISTS = {
+    "AUTOMATION": CL_AUTOMATION,
+    "FLEET": CL_FLEET,
+    "FUEL": CL_FUEL,
     "LCA_SCOPE": CL_LCA_SCOPE,
     "MODE": CL_MODE,
     "OPERATOR": CL_OPERATOR,
+    "POLLUTANT": CL_POLLUTANT,
     "TYPE": CL_TYPE,
+    "VEHICLE": CL_VEHICLE,
 }

--- a/item/sdmx.py
+++ b/item/sdmx.py
@@ -273,6 +273,7 @@ CONCEPT_SCHEMES = [
 ]
 
 CL_AUTOMATION = (
+    Code(id="_Z", name="Not applicable"),
     Code(id="HUMAN", name="Human", description="Vehicle operated by a human driver."),
     Code(
         id="AV", name="Automated", description="Fully-automated (self-driving) vehicle."
@@ -280,6 +281,7 @@ CL_AUTOMATION = (
 )
 
 CL_FLEET = (
+    Code(id="_Z", name="Not applicable"),
     Code(id="ALL", description="All vehicles in use in the reporting period."),
     Code(id="NEW", description="Only newly-sold vehicles in the reporting period."),
     Code(
@@ -291,6 +293,7 @@ CL_FLEET = (
 )
 
 CL_FUEL = (
+    Code(id="_Z", name="Not applicable"),
     Code(id="ALL", description="All fuels."),
     Code(
         id="LIQUID",
@@ -308,12 +311,14 @@ CL_FUEL = (
 )
 
 CL_LCA_SCOPE = (
+    Code(id="_Z", name="Not applicable"),
     Code(id="TTW", name="Tank-to-wheels"),
     Code(id="WTT", name="Well-to-tank"),
     Code(id="WTW", name="Well-to-wheels"),
 )
 
 CL_MODE = (
+    Code(id="_Z", name="Not applicable"),
     Code(id="ALL", name="All", description="All transport modes."),
     Code(id="AIR", name="Aviation"),
     Code(id="LAND", name="Land transport"),
@@ -323,6 +328,7 @@ CL_MODE = (
 )
 
 CL_OPERATOR = (
+    Code(id="_Z", name="Not applicable"),
     Code(
         id="OWN",
         name="Own-supplied",
@@ -342,6 +348,7 @@ CL_OPERATOR = (
 )
 
 CL_POLLUTANT = (
+    Code(id="_Z", name="Not applicable"),
     Code(
         id="GHG",
         name="GHG",
@@ -376,11 +383,13 @@ CL_POLLUTANT = (
 )
 
 CL_SERVICE = (
+    Code(id="_Z", name="Not applicable"),
     Code(id="P", name="Passenger"),
     Code(id="F", name="Freight"),
 )
 
 CL_VEHICLE = (
+    Code(id="_Z", name="Not applicable"),
     Code(id="ALL", description="All vehicle types."),
     Code(
         id="LDV",

--- a/item/sdmx.py
+++ b/item/sdmx.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
-import sdmx.model as m
 import sdmx.message as msg
+import sdmx.model as m
 from sdmx.model import Code, Concept
 
 #: Current version of all data structures.

--- a/item/structure.py
+++ b/item/structure.py
@@ -88,7 +88,6 @@ def read_concepts_yaml(path: Path) -> Dict[str, ConceptScheme]:
 
     See Also
     --------
-    :ref:`concepts-yaml`
     read_items
     """
     data = yaml.safe_load(open(path))
@@ -110,7 +109,6 @@ def read_measures_yaml(path: Path) -> ConceptScheme:
 
     See Also
     --------
-    :ref:`measures-yaml`
     read_items
     """
     data = yaml.safe_load(open(path))

--- a/item/structure.py
+++ b/item/structure.py
@@ -1,3 +1,5 @@
+import logging
+from functools import lru_cache
 from itertools import product
 from pathlib import Path
 from typing import Dict, List
@@ -9,6 +11,27 @@ from sdmx.model import Concept, ConceptScheme
 
 from item.common import paths
 from item.sdmx import generate
+
+log = logging.getLogger(__name__)
+
+
+@lru_cache()
+def column_name(id: str) -> str:
+    """Return a human-readable name for a dimension in the historical DSD."""
+    try:
+        value = dict(
+            YEAR="Year",
+            ID="ID",
+        )[id]
+        log.warning(f"Deprecated dimension id: {repr(id)}")
+        return value
+    except KeyError:
+        return (
+            generate()
+            .structure["HISTORICAL"]
+            .dimensions.get(id.upper())
+            .concept_identity.name.localized_default()
+        )
 
 
 def common_dim_dummies():

--- a/item/structure/__init__.py
+++ b/item/structure/__init__.py
@@ -1,0 +1,9 @@
+from item.structure.common import column_name
+from item.structure.sdmx import generate
+from item.structure.template import make_template
+
+__all__ = [
+    "column_name",
+    "generate",
+    "make_template",
+]

--- a/item/structure/base.py
+++ b/item/structure/base.py
@@ -7,9 +7,9 @@ from sdmx.model import (
     Code,
     Concept,
     ConceptScheme,
-    Contact,
     ConstraintRole,
     ConstraintRoleType,
+    Contact,
     ContentConstraint,
     DataStructureDefinition,
 )

--- a/item/structure/common.py
+++ b/item/structure/common.py
@@ -1,0 +1,22 @@
+import logging
+from functools import lru_cache
+
+from item.structure.sdmx import generate
+
+log = logging.getLogger(__name__)
+
+
+@lru_cache()
+def column_name(id: str) -> str:
+    """Return a human-readable name for a dimension in the historical DSD."""
+    try:
+        value = dict(VARIABLE="Variable", YEAR="Year", ID="ID")[id]
+        log.warning(f"Deprecated dimension id: {repr(id)}")
+        return value
+    except KeyError:
+        return (
+            generate()
+            .structure["HISTORICAL"]
+            .dimensions.get(id.upper())
+            .concept_identity.name.localized_default()
+        )

--- a/item/structure/common.py
+++ b/item/structure/common.py
@@ -18,5 +18,5 @@ def column_name(id: str) -> str:
             generate()
             .structure["HISTORICAL"]
             .dimensions.get(id.upper())
-            .concept_identity.name.localized_default()
+            .concept_identity.name.localized_default()  # type: ignore [union-attr]
         )

--- a/item/structure/sdmx.py
+++ b/item/structure/sdmx.py
@@ -1,0 +1,312 @@
+import logging
+from collections import ChainMap
+from datetime import datetime
+from functools import lru_cache
+from typing import List
+
+import sdmx.message as msg
+import sdmx.model as m
+import numpy as np
+from sdmx import Client
+
+from item.structure import base
+
+log = logging.getLogger(__name__)
+
+
+def _get_anno(obj, id):
+    """Wrapper around :meth:`AnnotableArtefact.get_annotation`.
+
+    Like :func:`_pop_anno`, but doesn't remove the annotation.
+    """
+    try:
+        return eval(obj.get_annotation(id=id).text.localized_default())
+    except KeyError:
+        return None
+
+
+def _pop_anno(obj, id):
+    """Wrapper around :meth:`AnnotableArtefact.pop_annotation`.
+
+    Inverse of :func:`_annotate`.
+    """
+    try:
+        return eval(obj.pop_annotation(id=id).text.localized_default())
+    except KeyError:
+        return None
+
+
+@lru_cache()
+def get_cdc():
+    """Retrieve the ``CROSS_DOMAIN_CONCEPTS`` from the SDMX Global Registry."""
+    id = "CROSS_DOMAIN_CONCEPTS"
+    msg = Client("SGR").conceptscheme(id)
+    return msg.concept_scheme[id]
+
+
+@lru_cache()
+def generate() -> msg.StructureMessage:
+    """Return the SDMX data structures for iTEM data."""
+    item_agency = base.AS_ITEM.items["iTEM"]
+
+    sm = msg.StructureMessage(
+        prepared=datetime.now(), header=msg.Header(sender=item_agency)
+    )
+
+    # Add the AgencyScheme containing iTEM
+    sm.organisation_scheme[base.AS_ITEM.id] = base.AS_ITEM
+
+    # Add concept schemes
+    for cs in base.CONCEPT_SCHEMES:
+        sm.concept_scheme[cs.id] = cs
+        # Ensure concepts are associated to their parent scheme
+        for item in cs:
+            item.parent = item.parent or cs
+
+    # Process and add code lists
+    for id, codes in base.CODELISTS.items():
+        # Create a code list object
+        cl = m.Codelist(id=f"CL_{id}")
+
+        # Add each code and any children
+        # TODO move this upstream to sdmx1
+        for c in codes:
+            cl.append(c)
+            cl.extend(c.child)
+
+        # Add to the message
+        sm.codelist[cl.id] = cl
+
+    # Process and add data structure definitions
+    for dsd in base.DATA_STRUCTURES:
+        prepare_dsd(dsd, sm)
+
+        # Add to the message
+        sm.structure[dsd.id] = dsd
+
+    # Process and add content constraints
+    for cc in base.CONSTRAINTS:
+        # Add the constraint to the message
+        sm.constraint[cc.id] = cc
+
+        # Look up the object that is constrained
+        try:
+            dsd = sm.structure[cc.id]
+        except KeyError:
+            log.info(f"No constraint(s) for {repr(dsd)}")
+            continue
+
+        # Update the constraint with a reference to the DSD
+        cc.content.add(dsd)
+
+        # Convert annotations into DataKeySet and CubeRegion objects, associated with
+        # the DSDs
+        dks_from_anno(cc, dsd)
+        cr_from_anno(cc, dsd)
+
+        # Update the constraint using applicable CubeRegions from GENERAL0, GENERAL1,
+        # etc.
+        merge_general_constraints(cc, dsd, sm)
+
+    # Add MaintainableArtefact properties to all objects
+    for kind in (
+        "codelist",
+        "concept_scheme",
+        "constraint",
+        "organisation_scheme",
+        "structure",
+    ):
+        for obj in getattr(sm, kind).values():
+            obj.maintainer = item_agency
+            obj.version = base.VERSION
+            obj.is_external_reference = False
+
+    return sm
+
+
+def merge_dsd(
+    sm: msg.StructureMessage,
+    target: str,
+    others: List[str],
+    fill_value: str = "_Z",
+) -> m.DataSet:
+    """`Merge` 2 or more data structure definitions."""
+    dsd_target = sm.structure[target]
+
+    # Create a temporary DataSet
+    ds = m.DataSet(structured_by=dsd_target)
+
+    # Count of keys
+    count = 0
+
+    for dsd_id in others:
+        # Retrieve the DSD
+        dsd = sm.structure[dsd_id]
+
+        # Retrieve a constraint that affects this DSD
+        ccs = [cc for cc in sm.constraint.values() if dsd in cc.content]
+        assert len(ccs) <= 1
+        cc = ccs[0] if len(ccs) and len(ccs[0].data_content_region) else None
+
+        # Key for the VARIABLE dimension
+        base_key = m.Key(VARIABLE=dsd_id, described_by=dsd_target.dimensions)
+
+        # Add KeyValues for other dimensions included in the target but not in this DSD
+        for dim in dsd_target.dimensions:
+            if dim.id in base_key.values or dim.id in dsd.dimensions:
+                continue
+            base_key[dim.id] = dim.local_representation.enumerated[fill_value]
+
+        # Iterate over the possible keys in `dsd`; add to `k`
+        ds.add_obs(
+            m.Observation(dimension=(base_key + key).order(), value=np.NaN)
+            for key in dsd.iter_keys(constraint=cc)
+        )
+
+        log.info(f"{repr(dsd)}: {len(ds.obs) - count} keys")
+        count = len(ds.obs)
+
+    log.info(
+        f"Total keys: {len(ds.obs)}\n"
+        + "\n".join(map(lambda o: repr(o.dimension), ds.obs[:5]))
+    )
+
+    return ds
+
+
+def prepare_dsd(dsd: m.DataStructureDefinition, sm: msg.StructureMessage):
+    """Populate data structures within `dsd`."""
+    # Concepts for each dimension of each DSD
+    dsd_concepts = ChainMap(
+        sm.concept_scheme["TRANSPORT"],
+        sm.concept_scheme["MODELING"],
+        # Retrieve the CROSS_DOMAIN_CONCEPTS scheme from the SDMX Global Registry
+        get_cdc(),
+    )
+
+    try:
+        # Pop an annotation and use it to produce a list of dimension IDs
+        dims = _pop_anno(dsd, "_dimensions").split()
+    except AttributeError:
+        # No dimensions
+        dims = []
+
+    # Add common dimensions
+    dims = dims + ["REF_AREA", "TIME_PERIOD"]
+
+    # Add dimensions to the data structure
+    for order, concept_id in enumerate(dims):
+        # Locate the corresponding concept in one of three concept schemes
+        concept = dsd_concepts.get(concept_id)
+
+        if concept_id == "VARIABLE":
+            d = m.MeasureDimension(
+                id="VARIABLE",
+                name="Variable",
+                description="Reference to a concept from CL_TRANSPORT_MEASURES.",
+                local_representation=m.Representation(
+                    enumerated=sm.concept_scheme["TRANSPORT_MEASURE"]
+                ),
+            )
+        elif concept is None:
+            raise KeyError(concept_id)
+        else:
+            # Create the dimension, referring to the concept
+            d = m.Dimension(
+                id=concept_id, name=concept.name, concept_identity=concept, order=order
+            )
+
+            try:
+                # The dimension is represented by the corresponding code list, if any
+                d.local_representation = m.Representation(
+                    enumerated=sm.codelist[f"CL_{concept_id}"]
+                )
+            except KeyError:
+                pass  # No iTEM codelist for this concept
+
+        # Append this dimension
+        dsd.dimensions.append(d)
+
+    # Add a primary measure: either the matching one
+    concept = dsd_concepts.get(dsd.id) or dsd_concepts.get("OBS_VALUE")
+    dsd.measures.append(
+        m.PrimaryMeasure(id=concept.id, name=concept.name, concept_identity=concept)
+    )
+
+    # Assign order to the dimensions
+    dsd.dimensions.assign_order()
+
+
+def cr_from(info: dict, dsd: m.DataStructureDefinition) -> m.CubeRegion:
+    """Create a :class:`.CubeRegion` from a simple :class:`dict` of `info`."""
+    cr = m.CubeRegion(included=info.pop("included", True))
+    for dim_id, values in info.items():
+        dim = dsd.dimensions.get(dim_id)
+
+        values = values.split()
+        if values[0] == "!":
+            included = False
+            values.pop(0)
+        else:
+            included = True
+
+        cr.member[dim] = m.MemberSelection(
+            included=included,
+            values_for=dim,
+            values=[m.MemberValue(value=value) for value in values],
+        )
+
+    return cr
+
+
+def cr_from_anno(obj: m.ContentConstraint, dsd: m.DataStructureDefinition) -> None:
+    """Convert an annotation on `obj` into a :class:`.CubeRegion` constraint."""
+    all_info = _pop_anno(obj, "_data_content_region")
+
+    if all_info is None:
+        return
+
+    for info in all_info:
+        obj.data_content_region.append(cr_from(info, dsd))
+
+
+def dks_from_anno(obj: m.ContentConstraint, dsd: m.DataStructureDefinition) -> None:
+    """Convert an annotation on `obj` into a :class:`.DataKeySet` constraint."""
+    info = _pop_anno(obj, "_data_content_keys")
+    if info is None:
+        return
+
+    dks = m.DataKeySet(included=True, keys=[])
+    for dim_id, values in info.items():
+        dim = dsd.dimensions.get(dim_id)
+
+        for value in values:
+            dks.keys.append(
+                m.DataKey(
+                    key_value={dim: m.ComponentValue(value_for=dim, value=value)},
+                    included=True,
+                )
+            )
+
+    obj.data_content_keys = dks
+
+
+def merge_general_constraints(
+    cc: m.ContentConstraint,
+    dsd: m.DataStructureDefinition,
+    sm: msg.StructureMessage,
+) -> None:
+    """Merge general constraints from `sm` into `cc` if relevant to `dsd`."""
+    for other_cc in filter(
+        lambda obj: obj.id.startswith("GENERAL"), sm.constraint.values()
+    ):
+        for i, info in enumerate(_get_anno(other_cc, "_data_content_region")):
+            if not (set(info.keys()) - {"included"}) < set(
+                dim.id for dim in dsd.dimensions
+            ):
+                continue
+
+            # log.debug(
+            #     f"Extend {repr(cc)} using {repr(other_cc)}.data_content_region[{i}]"
+            # )
+            cc.data_content_region.append(cr_from(info, dsd))

--- a/item/tests/test_common.py
+++ b/item/tests/test_common.py
@@ -4,7 +4,7 @@ from item.common import init_log, log
 
 
 def test_log(item_tmp_dir):
-    init_log()
+    init_log(file=True)
 
     # Log using the standard Python method
     logger = logging.getLogger("item")

--- a/item/tests/test_historical.py
+++ b/item/tests/test_historical.py
@@ -109,7 +109,7 @@ def test_A003():
 
     # Number of unique values computed
     # TODO make this more flexible/robust to changes in the upstream data
-    assert 954 <= len(result)
+    assert 950 <= len(result)
 
     # A specific value is present and as expected
     obs = result.query("`ISO Code` == 'USA' and Year == 2015")["Value"].squeeze()

--- a/item/tests/test_structure.py
+++ b/item/tests/test_structure.py
@@ -1,12 +1,14 @@
+import logging
 from itertools import product
 
 import sdmx
 
-from item.sdmx import generate
-from item.structure import column_name, make_template
+from item.structure import column_name, generate, make_template
 
 
 def test_column_name(caplog):
+    caplog.set_level(logging.WARNING)
+
     # Correctly retrieves the name of a Concept from the data structures
     assert column_name("VEHICLE") == "Vehicle type"
 
@@ -39,4 +41,12 @@ def test_sdmx_roundtrip(tmp_path):
     # Structure can be read
     sm = sdmx.read_sdmx(path)
 
-    assert 3 == len(sm.constraint["PRICE_FUEL"].data_content_keys)
+    # One CubeRegion
+    assert 1 == len(sm.constraint["PRICE_FUEL"].data_content_region)
+
+    # One dimension with a MemberSelection
+    cr = sm.constraint["PRICE_FUEL"].data_content_region[0]
+    assert {"FUEL"} == set(d.id for d in cr.member.keys())
+
+    # 3 values in the MemberSelection
+    assert 3 == len(cr.member["FUEL"].values)

--- a/item/tests/test_structure.py
+++ b/item/tests/test_structure.py
@@ -1,3 +1,6 @@
+import sdmx
+
+from item.sdmx import generate
 from item.structure import column_name, make_template
 
 
@@ -19,3 +22,16 @@ def test_make_template(tmp_path):
 
     assert 2493 + 1 == sum(1 for _ in open(tmp_path / "template.csv"))
     assert 2493 + 2 == sum(1 for _ in open(tmp_path / "index.csv"))
+
+
+def test_sdmx_roundtrip(tmp_path):
+    path = tmp_path / "structure.xml"
+
+    # Structure can be written
+    with open(path, "wb") as f:
+        f.write(sdmx.to_xml(generate(), pretty_print=True))
+
+    # Structure can be read
+    sm = sdmx.read_sdmx(path)
+
+    assert 3 == len(sm.constraint["PRICE_FUEL"].data_content_keys)

--- a/item/tests/test_structure.py
+++ b/item/tests/test_structure.py
@@ -1,3 +1,5 @@
+from itertools import product
+
 import sdmx
 
 from item.sdmx import generate
@@ -17,11 +19,14 @@ def test_make_template(tmp_path):
     make_template(output_path=tmp_path)
 
     # Produces 4 files
-    for name in ["index.csv", "index.xlsx", "template.csv", "template.xlsx"]:
-        assert (tmp_path / name).exists()
+    for base, suffix in product(["full", "condensed", "index"], [".csv", ".xlsx"]):
+        assert (tmp_path / base).with_suffix(suffix).exists()
 
-    assert 2493 + 1 == sum(1 for _ in open(tmp_path / "template.csv"))
-    assert 2493 + 2 == sum(1 for _ in open(tmp_path / "index.csv"))
+    # Files have the expected length
+    expected_keys = 6162
+    assert expected_keys + 1 == sum(1 for _ in open(tmp_path / "condensed.csv"))
+    assert expected_keys + 1 == sum(1 for _ in open(tmp_path / "full.csv"))
+    assert expected_keys + 2 == sum(1 for _ in open(tmp_path / "index.csv"))
 
 
 def test_sdmx_roundtrip(tmp_path):

--- a/item/tests/test_structure.py
+++ b/item/tests/test_structure.py
@@ -1,4 +1,13 @@
-from item.structure import make_template
+from item.structure import column_name, make_template
+
+
+def test_column_name(caplog):
+    # Correctly retrieves the name of a Concept from the data structures
+    assert column_name("VEHICLE") == "Vehicle type"
+
+    # Warning is logged for deprecated IDs
+    assert column_name("YEAR") == "Year"
+    assert "Deprecated dimension id: 'YEAR'" in caplog.messages
 
 
 def test_make_template(tmp_path):

--- a/item/tests/test_structure.py
+++ b/item/tests/test_structure.py
@@ -1,4 +1,3 @@
-import logging
 from itertools import product
 
 import sdmx
@@ -7,7 +6,8 @@ from item.structure import column_name, generate, make_template
 
 
 def test_column_name(caplog):
-    caplog.set_level(logging.WARNING)
+    # Force clear of lru_cache()
+    column_name.cache_clear()
 
     # Correctly retrieves the name of a Concept from the data structures
     assert column_name("VEHICLE") == "Vehicle type"

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     pprint36
     pycountry
     pyyaml
-    sdmx1 >= 1.5
+    sdmx1 >= 2.0
     setuptools >= 41
     xarray
 setup_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     pprint36
     pycountry
     pyyaml
-    sdmx1 >= 2.0
+    sdmx1 >= 2.4.0
     setuptools >= 41
     xarray
 setup_requires =


### PR DESCRIPTION
This code uses the [`sdmx1` package]() to give a complete and rigorous definition of the concepts, measures, codes, etc. used to structure the iTEM historical *and* model data.

**Details**

See the updated “Data structures” page in the documentation for more details, including motivation. This is a preview version built from the branch for this PR:
- https://transportenergy.readthedocs.io/en/feature-sdmx-dsd/structure.html
- The actual structures.xml generated is included in full at: https://transportenergy.readthedocs.io/en/feature-sdmx-dsd/metadata.html#sdmx-metadata-structure-xml

**PR checklist**
- [x] Complete code lists:
  - [x] Convert the following codelists from the versions in the old `concepts.yaml`: automation, fleet, fuel, technology, pollutant, vehicle.
  - ~Generate a `CL_MODEL` from existing metadata.~ Deferred; see #65.
- [x] Add model and scenario concepts.
- [x] Make reference to the [`SDMX:CROSS_DOMAIN_CONCEPTS` scheme](https://registry.sdmx.org/items/conceptscheme.html) where appropriate. 
- [x] Add a distinct DSD for model data.
- [x] Improve existing code using the SDMX data structures:
  - [x] Remove `concepts.yaml` and `measures.yaml`, now obsolete.
  - [x] `item.structure.make_template()`
  - [x] Use the DSD instead of the `item.historical.scripts.util.managers.dataframe.ColumnName` enum in data processing scripts.
- [x] Expand documentation with:
  - [x] Code examples for retrieving code lists.