### PR TITLE
Extend documentation of historical.process()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ R/*.Rcheck
 
 # Access keys for CI deployment
 ci/*.json
+
+# Editors
+/**/.idea
+*.eggs
+

--- a/item/historical/__init__.py
+++ b/item/historical/__init__.py
@@ -8,10 +8,9 @@ import pycountry
 import yaml
 
 from item.common import paths
-from item.remote import OpenKAPSARC, get_sdmx
-
 from item.historical.scripts import T000, T001, T003, T009
 from item.historical.scripts.util.managers.dataframe import ColumnName
+from item.remote import OpenKAPSARC, get_sdmx
 
 log = logging.getLogger(__name__)
 

--- a/item/historical/__init__.py
+++ b/item/historical/__init__.py
@@ -10,8 +10,8 @@ import yaml
 from item.common import paths
 from item.remote import OpenKAPSARC, get_sdmx
 
-from .scripts import T000, T001, T003, T009
-from .scripts.util.managers.dataframe import ColumnName
+from item.historical.scripts import T000, T001, T003, T009
+from item.historical.scripts.util.managers.dataframe import ColumnName
 
 log = logging.getLogger(__name__)
 
@@ -170,6 +170,17 @@ def process(id):
        :data:`COMMON_DIMS` :class:`dict`.
     8. Order columns according to :class:`.ColumnName`.
     9. Output data to two files. See :meth:`cache_results`.
+
+    Parameters
+    ----------
+    id : int
+        Data source id, as listed in :data:`.MODULES`. E.g. ``0`` imports data from
+        from file :file:`T000.csv`.
+
+    Returns
+    -------
+    DataFrame : :class:`pandas.DataFrame`
+        Apart from generating :meth:`cache_results`, returns dataset as a DataFrame.
 
     """
     id_str = source_str(id)


### PR DESCRIPTION
When trying to retrieve data from `T000.csv`, it was not fully clear how to do so in an efficient manner. When reading historical.process() [docu](https://transportenergy.readthedocs.io/en/latest/historical.html?highlight=historical.process#item.historical.process), information about that function was missing and what was exactly the format of its argument `id`.

This PR extends its docstring and add example of `id` argument.