### PR TITLE
Update CI configuration

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   lint:
     continue-on-error: true
-    name: black, flake8, twine
+    name: black, flake8
     runs-on: ubuntu-latest
 
     steps:
@@ -42,12 +42,6 @@ jobs:
       run: |
         pip install isort
         isort --check-only .
-
-    - name: Build package
-      run: |
-        pip install twine wheel
-        python3 setup.py bdist_wheel sdist
-        twine check dist/*
 
   mypy-sphinx:
     continue-on-error: true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,9 +2,9 @@ name: Code quality
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   lint:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,53 @@
+name: Build package / publish
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ "v*" ]
+  release:
+    types: [ published ]
+  # Check that package can be built even on PRs
+  pull_request:
+    branches: [ main ]
+
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - uses: actions/setup-python@v2
+
+    - name: Cache Python packages
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/pip
+        key: publish-${{ runner.os }}
+
+    - name: Upgrade pip, wheel, setuptools-scm
+      run: python -m pip install --upgrade pip wheel setuptools-scm twine
+
+    - name: Build package
+      run: |
+        python3 setup.py bdist_wheel sdist
+        twine check dist/*
+
+    - name: Publish to TestPyPI
+      uses: pypa/gh-action-pypi-publish@v1.4.1
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      with:
+        user: __token__
+        password: ${{ secrets.TESTPYPI_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@v1.4.1
+      if: github.event_name == 'release'
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -37,6 +37,8 @@ jobs:
           python-version: "3.9"
           run-diagnostics: false
 
+      fail-fast: false
+
     runs-on: ${{ matrix.os }}
 
     name: ${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  schedule:
+  - cron: "0 5 * * *"
 
 env:
   # Location of RCLONE configuration file
@@ -15,7 +17,7 @@ env:
   # True if the event is a pull request and the incoming branch is within the
   # transportenergy/database repo (as opposed to a fork). Only under this
   # condition is the GCS_SERVICE_ACCOUNT_* secret available.
-  pr_from_main_repo: github.event_name == 'pull_request' && startsWith(github.event.pull_request.head.label, 'transportenergy:')
+  pr_from_main_repo: github.event_name != 'pull_request' || startsWith(github.event.pull_request.head.label, 'transportenergy:')
 
 jobs:
   pytest:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -2,9 +2,9 @@ name: Test suite & diagnostics
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 env:
   # Location of RCLONE configuration file
@@ -19,21 +19,32 @@ env:
 
 jobs:
   pytest:
-    runs-on: ubuntu-latest
-
     strategy:
       matrix:
         include:
-        - python-version: "3.7"
+        - os: ubuntu-latest
+          python-version: "3.7"
           run-diagnostics: false
-        - python-version: "3.8"
+        - os: ubuntu-latest
+          python-version: "3.8"
           run-diagnostics: false
-        - python-version: "3.9"
+        - os: ubuntu-latest
+          python-version: "3.9"
           run-diagnostics: true
+        - os: windows-latest
+          python-version: "3.9"
+          run-diagnostics: false
 
-    name: py${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+
+    name: ${{ matrix.os }}-py${{ matrix.python-version }}
 
     steps:
+    - name: Cancel previous runs that have not completed
+      uses: styfle/cancel-workflow-action@0.7.0
+      with:
+        access_token: ${{ github.token }}
+
     - uses: actions/checkout@v2
       with:
         submodules: true
@@ -48,7 +59,8 @@ jobs:
         path: |
           ~/.cache/pip
           ~/.cache/rclone*.zip
-        key: ubuntu-latest-${{ matrix.python-version }}
+          ~/appdata/local/pip/cache
+        key: ${{ matrix.os }}-${{ matrix.python-version }}
 
     - name: Upgrade pip, wheel
       run: python -m pip install --upgrade pip wheel

--- a/doc/developing.rst
+++ b/doc/developing.rst
@@ -48,19 +48,19 @@ Preparing a new release
 
 Before releasing, check:
 
-- https://github.com/transportenergy/actions?query=workflow:pytest+branch:master to ensure that the push and scheduled builds are passing.
-- https://readthedocs.org/projects/transportenergy/builds/ to ensure that the docs build
-  is passing.
+- https://github.com/transportenergy/database/actions?query=workflow:pytest+branch:main to ensure that the push and scheduled builds are passing.
+- https://readthedocs.org/projects/transportenergy/builds/ to ensure that the docs build is passing.
 
 Address any failures before releasing.
 
+1. Edit :file:`doc/whatsnew.rst`.
+   Comment the heading "Next release", then insert another heading below it, at the same level, with the version number and date.
+   Make a commit with a message like "Mark vX.Y.Z in doc/whatsnew".
 
-1. Edit :file:`doc/whatsnew.rst` to replace "Next release" with the version number and date.
-   Make a commit with a message like "Mark vX.Y.Z in whatsnew.rst".
+2. Tag the release candidate version, i.e. with a ``rcN`` suffix, and push::
 
-2. Tag the version, e.g.::
-
-    $ git tag v2030.10.4b4
+    $ git tag v2021.5.4rc1
+    $ git push --tags origin main
 
    :mod:`item` uses a versioning scheme of **[year].[month].[day]**.
    For instance, the version released on October 4, 2030 will have the version ``2030.10.4``.
@@ -69,33 +69,24 @@ Address any failures before releasing.
    - There are no leading zeroes.
    - If two versions are to be released in a single day—for instance, to fix a bug only spotted after release—a fourth version part can be added, e.g. ``2030.10.4.1``.
 
-3. Test-build and check the source and binary packages::
+3. Check:
 
-    $ rm -rf build dist
-    $ python setup.py bdist_wheel sdist
-    $ twine check dist/*
+   - at https://github.com/transportenergy/database/actions?query=workflow:publish that the workflow completes: the package builds successfully and is published to TestPyPI.
+   - at https://test.pypi.org/project/transport-energy/ that:
+
+      - The package can be downloaded, installed and run.
+      - The README is rendered correctly.
 
    Address any warnings or errors that appear.
-   If needed, make a new commit and go back to step (2).
+   If needed, make a new commit and go back to step (2), incrementing the rc number.
 
-4. Upload the packages to the TEST instance of PyPI::
+4. (optional) Tag the release itself and push::
 
-    $ twine upload -r testpypi dist/*
+    $ git tag v2021.5.4
+    $ git push --tags origin main
 
-5. Check at https://test.pypi.org/project/transport-energy/ that:
+   This step (but *not* step (2)) can also be performed directly on GitHub; see (5), next.
 
-   - The package can be downloaded, installed and run.
-   - The README is rendered correctly.
-   - Links to the documentation go to the correct version.
+5. Visit https://github.com/transportenergy/database/releases and mark the new release: either using the pushed tag from (4), or by creating the tag and release simultaneously.
 
-   If not, modify the code and go back to step (2).
-
-6. Upload to PyPI::
-
-    $ twine upload dist/*
-
-7. Push the commit(s) and tag to GitHub::
-
-    $ git push --tags
-
-8. Edit :file:`doc/whatsnew.rst` to add a new heading for the next release.
+6. Check at https://github.com/transportenergy/database/actions?query=workflow:publish and https://pypi.org/project/transport-energy/ that the distributions are published.

--- a/item/model/dimensions.py
+++ b/item/model/dimensions.py
@@ -57,10 +57,10 @@ def load():
 
     # Read the lists of allowable labels for each data dimension
     data = OrderedDict()
-    path = join(paths["data"], "model", "dimensions")
+    path = paths["data"].joinpath("model", "dimensions")
     for k in ["variable", "mode", "technology", "fuel", "match"]:
-        with open(join(path, "{}.yaml".format(k))) as f:
-            data[k] = yaml.load(f, Loader=yaml.SafeLoader)
+        with open(path.joinpath(k).with_suffix(".yaml"), encoding="utf-8") as f:
+            data[k] = yaml.safe_load(f)
     variable, mode, tech, fuel, match = data.values()
 
     # Sets of modes, for convenience

--- a/item/remote/sdmx.py
+++ b/item/remote/sdmx.py
@@ -1,7 +1,8 @@
+import pandas as pd
 import sdmx
 
 
-def get_sdmx(source=None, **args):
+def get_sdmx(source: str = None, **args) -> pd.DataFrame:
     """Retrieve data from *source* using :mod:`sdmx`.
 
     Arguments
@@ -16,7 +17,7 @@ def get_sdmx(source=None, **args):
     pandas.DataFrame
     """
     # SDMX client for the data source
-    req = sdmx.Request(source=source)
+    req = sdmx.Client(source=source)
 
     # commented: for debugging
     # args.setdefault('tofile', 'debug.json')

--- a/item/tests/conftest.py
+++ b/item/tests/conftest.py
@@ -59,5 +59,4 @@ def item_tmp_dir(tmp_path_factory, pytestconfig):
         # For use by test functions
         yield tmp_path
     finally:
-        # Remove the whole tree
-        shutil.rmtree(tmp_path)
+        pass


### PR DESCRIPTION
- Run on `main`, rather than `master` branch events.
- Add a Windows build (to catch e.g. #48).
- Add a nightly run of the pytest job—partly addresses #44, #54.
- Cancel previous workflow runs if not completed.