### PR TITLE
Adjust for NumPy 2.0

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -29,12 +29,14 @@ jobs:
         - ubuntu-latest
         - windows-latest
 
-        python-version:
-        - "3.8"
-        - "3.9"
-        - "3.10"
-        - "3.11"
-        - "3.12"
+        version:
+        - { python: "3.8",  others: "" }
+        # Pint 0.24 with numpy 2.0 compatibility is not available for Python 3.9.
+        # Use earlier numpy to be compatible with pint < 0.24.
+        - { python: "3.9",  others: "'numpy < 2'" }
+        - { python: "3.10", others: "" }
+        - { python: "3.11", others: "" }
+        - { python: "3.12", others: "" }
 
         # TEMPORARY Never run diagnostics
         run-diagnostics:
@@ -44,7 +46,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    name: ${{ matrix.os }}-py${{ matrix.python-version }}
+    name: ${{ matrix.os }}-py${{ matrix.version.python }}
 
     steps:
     - uses: actions/checkout@v4
@@ -53,7 +55,7 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ matrix.version.python }}
         cache: pip
         cache-dependency-path: "**/pyproject.toml"
 
@@ -61,7 +63,7 @@ jobs:
       run: python -m pip install --upgrade pip
 
     - name: Install the Python package and its dependencies
-      run: pip install .[tests]
+      run: pip install .[tests] ${{ matrix.version.others }}
 
     - name: Run pytest
       env:

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -12,6 +12,7 @@ Next release
 ============
 
 - Add :mod:`.A001` and :mod:`.A002` historical quality diagnostics (:pull:`74`).
+- Adjust for compatibility with `NumPy 2 <https://numpy.org/doc/stable/release/2.0.0-notes.html>`_ (:pull:`87`).
 
 
 v2021.5.4

--- a/item/structure/sdmx.py
+++ b/item/structure/sdmx.py
@@ -173,7 +173,7 @@ def merge_dsd(
 
         # Iterate over the possible keys in `dsd`; add to `k`
         ds.add_obs(
-            Observation(dimension=(base_key + key).order(), value=np.NaN)
+            Observation(dimension=(base_key + key).order(), value=np.nan)
             for key in dsd.iter_keys(constraint=cc)
         )
 

--- a/item/structure/template.py
+++ b/item/structure/template.py
@@ -156,7 +156,7 @@ def make_template(output_path: Optional[Path] = None, verbose: bool = True):
     log.info(f"Output to {output_path}/{{index,template}}.{{csv,xlsx}}")
 
     # "Index" format: only simple replacements, full dimensionality
-    df1 = df0.replace({"_Z": "", np.NaN: "", "(REF_AREA)": "…", "(TIME_PERIOD)": "…"})
+    df1 = df0.replace({"_Z": "", np.nan: "", "(REF_AREA)": "…", "(TIME_PERIOD)": "…"})
 
     df1.to_csv(output_path / "full.csv")
     df1.to_excel(output_path / "full.xlsx")


### PR DESCRIPTION
The release of [NumPy 2.0.0](https://numpy.org/doc/stable/release/2.0.0-notes.html) triggered [CI failures](https://github.com/transportenergy/database/actions/runs/9542233040/job/26296704067#step:6:194) because the code was using the deprecated `np.NaN` instead of `np.nan`.

This PR fixes.